### PR TITLE
feat(nodejs):  return score to rust and ts

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -56,7 +56,7 @@ jobs:
   type-check:
     name: "Type Check"
     timeout-minutes: 60
-    runs-on: ubuntu-2404-8x-x64
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
@@ -85,7 +85,7 @@ jobs:
   doctest:
     name: "Doctest"
     timeout-minutes: 60
-    runs-on: ubuntu-2404-8x-x64
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,7 @@ jobs:
     # To build all features, we need more disk space than is available
     # on the free OSS github runner. This is mostly due to the the
     # sentence-transformers feature.
-    runs-on: ubuntu-2404-4x-x64
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,6 +107,8 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Make Swap
         run: |
+          sudo swapoff /swapfile || true
+          sudo rm -f /swapfile
           sudo fallocate -l 16G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile

--- a/docs/src/js/namespaces/rerankers/classes/RRFReranker.md
+++ b/docs/src/js/namespaces/rerankers/classes/RRFReranker.md
@@ -8,6 +8,20 @@
 
 Reranks the results using the Reciprocal Rank Fusion (RRF) algorithm.
 
+## Param
+
+Constant used in the RRF formula (default `60`). Experiments
+  indicate that `k = 60` was near-optimal, but the choice is not critical.
+  See paper: https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
+
+## Param
+
+Controls which score columns appear in the output.
+  - `"relevance"` (default): Only the `_relevance_score` column is kept;
+    the raw `_distance` and `_score` columns are dropped.
+  - `"all"`: All score columns are retained alongside `_relevance_score`,
+    which is useful for debugging.
+
 ## Methods
 
 ### rerankHybrid()
@@ -36,12 +50,14 @@ rerankHybrid(
 ### create()
 
 ```ts
-static create(k): Promise<RRFReranker>
+static create(k, returnScore): Promise<RRFReranker>
 ```
 
 #### Parameters
 
 * **k**: `number` = `60`
+
+* **returnScore**: `"all"` \| `"relevance"` = `"relevance"`
 
 #### Returns
 

--- a/nodejs/__test__/rerankers.test.ts
+++ b/nodejs/__test__/rerankers.test.ts
@@ -78,8 +78,9 @@ describe("rerankers", function () {
   });
 
   it("will query with RRFReranker returnScore='all'", async function () {
-    // When returnScore="all", the raw score columns (_distance, _score) should
-    // be retained alongside _relevance_score.
+    // When returnScore="all", both _distance (vector) and _score (FTS) are
+    // retained alongside _relevance_score. Rows that only appear in one result
+    // set will have null for the score column from the other set.
     const reranker = await RRFReranker.create(60, "all");
     const result = await table
       .query()
@@ -90,14 +91,16 @@ describe("rerankers", function () {
       .toArray();
 
     expect(result).toHaveLength(2);
-    // At least one raw score column should be present
     const keys = Object.keys(result[0] as object);
-    expect(keys.some((k) => k === "_distance" || k === "_score")).toBe(true);
+    expect(keys).toContain("_distance");
+    expect(keys).toContain("_score");
     expect(keys).toContain("_relevance_score");
   });
 
-  it("will query with RRFReranker returnScore='relevance' drops raw scores", async function () {
-    // When returnScore="relevance" (default), _distance and _score are dropped.
+  it("will query with RRFReranker returnScore='relevance' preserves original behavior", async function () {
+    // When returnScore="relevance" (default), the original merge behavior is
+    // preserved: _score (FTS) is kept, _distance is not present because the
+    // merge uses the FTS schema as its base.
     const reranker = await RRFReranker.create(60, "relevance");
     const result = await table
       .query()
@@ -110,7 +113,6 @@ describe("rerankers", function () {
     expect(result).toHaveLength(2);
     const keys = Object.keys(result[0] as object);
     expect(keys).not.toContain("_distance");
-    expect(keys).not.toContain("_score");
     expect(keys).toContain("_relevance_score");
   });
 });

--- a/nodejs/__test__/rerankers.test.ts
+++ b/nodejs/__test__/rerankers.test.ts
@@ -76,4 +76,41 @@ describe("rerankers", function () {
 
     expect(result).toHaveLength(2);
   });
+
+  it("will query with RRFReranker returnScore='all'", async function () {
+    // When returnScore="all", the raw score columns (_distance, _score) should
+    // be retained alongside _relevance_score.
+    const reranker = await RRFReranker.create(60, "all");
+    const result = await table
+      .query()
+      .nearestTo([0.1, 0.1])
+      .fullTextSearch("dog")
+      .rerank(reranker)
+      .limit(5)
+      .toArray();
+
+    expect(result).toHaveLength(2);
+    // At least one raw score column should be present
+    const keys = Object.keys(result[0] as object);
+    expect(keys.some((k) => k === "_distance" || k === "_score")).toBe(true);
+    expect(keys).toContain("_relevance_score");
+  });
+
+  it("will query with RRFReranker returnScore='relevance' drops raw scores", async function () {
+    // When returnScore="relevance" (default), _distance and _score are dropped.
+    const reranker = await RRFReranker.create(60, "relevance");
+    const result = await table
+      .query()
+      .nearestTo([0.1, 0.1])
+      .fullTextSearch("dog")
+      .rerank(reranker)
+      .limit(5)
+      .toArray();
+
+    expect(result).toHaveLength(2);
+    const keys = Object.keys(result[0] as object);
+    expect(keys).not.toContain("_distance");
+    expect(keys).not.toContain("_score");
+    expect(keys).toContain("_relevance_score");
+  });
 });

--- a/nodejs/lancedb/rerankers/rrf.ts
+++ b/nodejs/lancedb/rerankers/rrf.ts
@@ -8,6 +8,15 @@ import { RrfReranker as NativeRRFReranker } from "../native";
 /**
  * Reranks the results using the Reciprocal Rank Fusion (RRF) algorithm.
  *
+ * @param k - Constant used in the RRF formula (default `60`). Experiments
+ *   indicate that `k = 60` was near-optimal, but the choice is not critical.
+ *   See paper: https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
+ * @param returnScore - Controls which score columns appear in the output.
+ *   - `"relevance"` (default): Only the `_relevance_score` column is kept;
+ *     the raw `_distance` and `_score` columns are dropped.
+ *   - `"all"`: All score columns are retained alongside `_relevance_score`,
+ *     which is useful for debugging.
+ *
  * @hideconstructor
  */
 export class RRFReranker {
@@ -18,9 +27,12 @@ export class RRFReranker {
     this.inner = inner;
   }
 
-  public static async create(k: number = 60) {
+  public static async create(
+    k: number = 60,
+    returnScore: "relevance" | "all" = "relevance",
+  ) {
     return new RRFReranker(
-      await NativeRRFReranker.tryNew(new Float32Array([k])),
+      await NativeRRFReranker.tryNew(new Float32Array([k]), returnScore),
     );
   }
 

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -489,23 +489,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.18.tgz",
-      "integrity": "sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==",
+      "version": "3.973.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
+      "integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/xml-builder": "^3.972.10",
-        "@smithy/core": "^3.23.8",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/signature-v4": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -514,13 +514,13 @@
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.4.tgz",
-      "integrity": "sha512-HKZIZLbRyvzo/bXZU7Zmk6XqU+1C9DjI56xd02vwuDIxedxBEqP17t9ExhbP9QFeNq/a3l9GOcyirFXxmbDhmw==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.5.tgz",
+      "integrity": "sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -528,16 +528,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.16.tgz",
-      "integrity": "sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.18.tgz",
+      "integrity": "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -545,21 +545,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz",
-      "integrity": "sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.20.tgz",
+      "integrity": "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.17",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.19",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -567,25 +567,25 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.16.tgz",
-      "integrity": "sha512-hzAnzNXKV0A4knFRWGu2NCt72P4WWxpEGnOc6H3DptUjC4oX3hGw846oN76M1rTHAOwDdbhjU0GAOWR4OUfTZg==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.20.tgz",
+      "integrity": "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/credential-provider-env": "^3.972.16",
-        "@aws-sdk/credential-provider-http": "^3.972.18",
-        "@aws-sdk/credential-provider-login": "^3.972.16",
-        "@aws-sdk/credential-provider-process": "^3.972.16",
-        "@aws-sdk/credential-provider-sso": "^3.972.16",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.16",
-        "@aws-sdk/nested-clients": "^3.996.6",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-env": "^3.972.18",
+        "@aws-sdk/credential-provider-http": "^3.972.20",
+        "@aws-sdk/credential-provider-login": "^3.972.20",
+        "@aws-sdk/credential-provider-process": "^3.972.18",
+        "@aws-sdk/credential-provider-sso": "^3.972.20",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -593,19 +593,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.16.tgz",
-      "integrity": "sha512-VI0kXTlr0o1FTay+Jvx6AKqx5ECBgp7X4VevGBEbuXdCXnNp7SPU0KvjsOLVhIz3OoPK4/lTXphk43t0IVk65w==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.20.tgz",
+      "integrity": "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.6",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -613,23 +613,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.17.tgz",
-      "integrity": "sha512-98MAcQ2Dk7zkvgwZ5f6fLX2lTyptC3gTSDx4EpvTdJWET8qs9lBPYggoYx7GmKp/5uk0OwVl0hxIDZsDNS/Y9g==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.21.tgz",
+      "integrity": "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.16",
-        "@aws-sdk/credential-provider-http": "^3.972.18",
-        "@aws-sdk/credential-provider-ini": "^3.972.16",
-        "@aws-sdk/credential-provider-process": "^3.972.16",
-        "@aws-sdk/credential-provider-sso": "^3.972.16",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.16",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/credential-provider-env": "^3.972.18",
+        "@aws-sdk/credential-provider-http": "^3.972.20",
+        "@aws-sdk/credential-provider-ini": "^3.972.20",
+        "@aws-sdk/credential-provider-process": "^3.972.18",
+        "@aws-sdk/credential-provider-sso": "^3.972.20",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -637,17 +637,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz",
-      "integrity": "sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.18.tgz",
+      "integrity": "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -655,19 +655,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.16.tgz",
-      "integrity": "sha512-b9of7tQgERxgcEcwAFWvRe84ivw+Kw6b3jVuz/6LQzonkomiY5UoWfprkbjc8FSCQ2VjDqKTvIRA9F0KSQ025w==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.20.tgz",
+      "integrity": "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.6",
-        "@aws-sdk/token-providers": "3.1003.0",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/token-providers": "3.1009.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -675,18 +675,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.16.tgz",
-      "integrity": "sha512-PaOH5jFoPQX4WkqpKzKh9cM7rieKtbgEGqrZ+ybGmotJhcvhI/xl69yCwMbHGnpQJJmHZIX9q2zaPB7HTBn/4w==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.20.tgz",
+      "integrity": "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.6",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -694,16 +694,16 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.19.tgz",
-      "integrity": "sha512-M/y+eA53imfFxA/QjrpfnyhG/eLIHxsNI6GmevwIVoX7E1vGYyevKt1iJ+aZwOVbL9lLeHtlBuYUEhYgVjwDpQ==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.21.tgz",
+      "integrity": "sha512-6wsIKQWJx87F1SZyQ/SfV7ovdvP0R2l5vpgSxT1+b9Qmx2IYnvWNNJfmpd3HJRN7aokEh/IV/eFlVnsZF2NXCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@smithy/core": "^3.23.8",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@smithy/core": "^3.23.11",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -779,24 +779,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.4.tgz",
-      "integrity": "sha512-7CH2jcGmkvkHc5Buz9IGbdjq1729AAlgYJiAvGq7qhCHqYleCsriWdSnmsqWTwdAfXHMT+pkxX3w6v5tJNcSug==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.0.tgz",
+      "integrity": "sha512-BmdDjqvnuYaC4SY7ypHLXfCSsGYGUZkjCLSZyUAAYn1YT28vbNMJNDwhlfkvvE+hQHG5RJDlEmYuvBxcB9jX1g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/crc64-nvme": "^3.972.4",
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/crc64-nvme": "^3.972.5",
+        "@aws-sdk/types": "^3.973.6",
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.19",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -805,15 +805,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
-      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -836,14 +836,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
-      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -851,16 +851,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
-      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/types": "^3.973.6",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -868,24 +868,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.18.tgz",
-      "integrity": "sha512-5E3XxaElrdyk6ZJ0TjH7Qm6ios4b/qQCiLr6oQ8NK7e4Kn6JBTJCaYioQCQ65BpZ1+l1mK5wTAac2+pEz0Smpw==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.20.tgz",
+      "integrity": "sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.8",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/signature-v4": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
+        "@smithy/core": "^3.23.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.19",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -909,18 +909,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.18.tgz",
-      "integrity": "sha512-KcqQDs/7WtoEnp52+879f8/i1XAJkgka5i4arOtOCPR10o4wWo3VRecDI9Gxoh6oghmLCnIiOSKyRcXI/50E+w==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.21.tgz",
+      "integrity": "sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@smithy/core": "^3.23.8",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.11",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -928,48 +929,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.6.tgz",
-      "integrity": "sha512-blNJ3ugn4gCQ9ZSZi/firzKCvVl5LvPFVxv24LprENeWI4R8UApG006UQkF4SkmLygKq2BQXRad2/anQ13Te4Q==",
+      "version": "3.996.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.10.tgz",
+      "integrity": "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.18",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.3",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.8",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.22",
-        "@smithy/middleware-retry": "^4.4.39",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.38",
-        "@smithy/util-defaults-mode-node": "^4.2.41",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -978,16 +979,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
-      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
+      "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -995,17 +996,17 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.6.tgz",
-      "integrity": "sha512-NnsOQsVmJXy4+IdPFUjRCWPn9qNH1TzS/f7MiWgXeoHs903tJpAWQWQtoFvLccyPoBgomKP9L89RRr2YsT/L0g==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.8.tgz",
+      "integrity": "sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/signature-v4": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1013,18 +1014,18 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1003.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1003.0.tgz",
-      "integrity": "sha512-SOyyWNdT7njKRwtZ1JhwHlH1csv6Pkgf305X96/OIfnhq1pU/EjmT6W6por57rVrjrKuHBuEIXgpWv8OgoMHpg==",
+      "version": "3.1009.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1009.0.tgz",
+      "integrity": "sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.6",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1032,13 +1033,13 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
-      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1059,16 +1060,16 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
-      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
-        "@smithy/util-endpoints": "^3.3.2",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1089,29 +1090,30 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
-      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.3.tgz",
-      "integrity": "sha512-8s2cQmTUOwcBlIJyI9PAZNnnnF+cGtdhHc1yzMMsSD/GR/Hxj7m0IGUE92CslXXb8/p5Q76iqOCjN1GFwyf+1A==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.7.tgz",
+      "integrity": "sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1127,13 +1129,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
-      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
+      "integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "fast-xml-parser": "5.4.1",
         "tslib": "^2.6.2"
       },
@@ -1180,6 +1182,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
       "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -4193,6 +4196,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4442,13 +4446,13 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
-      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4483,17 +4487,17 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
-      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.11.tgz",
+      "integrity": "sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4501,19 +4505,19 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.9",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.9.tgz",
-      "integrity": "sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==",
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -4523,16 +4527,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
-      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4615,15 +4619,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
-      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/querystring-builder": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -4648,13 +4652,13 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
-      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -4679,13 +4683,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
-      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4721,14 +4725,14 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
-      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4736,19 +4740,19 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.23",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.23.tgz",
-      "integrity": "sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==",
+      "version": "4.4.26",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.26.tgz",
+      "integrity": "sha512-8Qfikvd2GVKSm8S6IbjfwFlRY9VlMrj0Dp4vTwAuhqbX7NhJKE5DQc2bnfJIcY0B+2YKMDBWfvexbSZeejDgeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.9",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4756,19 +4760,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.40",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.40.tgz",
-      "integrity": "sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==",
+      "version": "4.4.43",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.43.tgz",
+      "integrity": "sha512-ZwsifBdyuNHrFGmbc7bAfP2b54+kt9J2rhFd18ilQGAB+GDiP4SrawqyExbB7v455QVR7Psyhb2kjULvBPIhvA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -4777,14 +4781,15 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
-      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4792,13 +4797,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
-      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4806,15 +4811,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
-      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4822,16 +4827,16 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
-      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/querystring-builder": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4839,13 +4844,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
-      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4853,13 +4858,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
-      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4867,13 +4872,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
-      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -4882,13 +4887,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
-      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4896,26 +4901,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
-      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0"
+        "@smithy/types": "^4.13.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
-      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4923,17 +4928,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
-      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -4943,18 +4948,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.3.tgz",
-      "integrity": "sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==",
+      "version": "4.12.6",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.6.tgz",
+      "integrity": "sha512-aib3f0jiMsJ6+cvDnXipBsGDL7ztknYSVqJs1FdN9P+u9tr/VzOR7iygSh6EUOdaBeMCMSh3N0VdyYsG4o91DQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.9",
-        "@smithy/middleware-endpoint": "^4.4.23",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4962,9 +4967,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4975,14 +4980,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
-      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5058,15 +5063,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.39",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.39.tgz",
-      "integrity": "sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==",
+      "version": "4.3.42",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.42.tgz",
+      "integrity": "sha512-0vjwmcvkWAUtikXnWIUOyV6IFHTEeQUYh3JUZcDgcszF+hD/StAsQ3rCZNZEPHgI9kVNcbnyc8P2CBHnwgmcwg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5074,18 +5079,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.42",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.42.tgz",
-      "integrity": "sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==",
+      "version": "4.2.45",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.45.tgz",
+      "integrity": "sha512-q5dOqqfTgUcLe38TAGiFn9srToKj2YCHJ34QGOLzM+xYLLA+qRZv7N+33kl1MERVusue36ZHnlNaNEvY/PzSrw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5093,14 +5098,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
-      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5121,13 +5126,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
-      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5135,14 +5140,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
-      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5150,15 +5155,15 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
-      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/types": "^4.13.0",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -5454,6 +5459,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5656,6 +5662,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5768,7 +5775,6 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-15.0.0.tgz",
       "integrity": "sha512-e6aunxNKM+woQf137ny3tp/xbLjFJS2oGQxQhYGqW6dGeIwNV1jOeEAeR6sS2jwAI2qLO83gYIP2MBz02Gw5Xw==",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.2",
         "@types/command-line-args": "^5.2.1",
@@ -5956,7 +5962,6 @@
       "version": "20.16.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.10.tgz",
       "integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -5964,8 +5969,7 @@
     "node_modules/apache-arrow/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "peer": true
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -6196,6 +6200,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001565",
         "electron-to-chromium": "^1.4.601",
@@ -6829,6 +6834,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7124,9 +7130,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "dev": true,
       "funding": [
         {
@@ -7134,7 +7140,10 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
     },
     "node_modules/fast-xml-parser": {
       "version": "5.4.1",
@@ -7245,10 +7254,11 @@
       "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ=="
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -7878,6 +7888,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9220,6 +9231,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -9956,9 +9983,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
@@ -10184,6 +10211,7 @@
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/nodejs/src/rerankers.rs
+++ b/nodejs/src/rerankers.rs
@@ -102,8 +102,14 @@ pub struct RRFReranker {
 
 #[napi]
 impl RRFReranker {
+    /// Create a new RRFReranker.
+    ///
+    /// * `k` – a single-element array holding the RRF constant (default 60).
+    /// * `return_score` – `"relevance"` (default) drops the raw `_distance` /
+    ///   `_score` columns from the output; `"all"` keeps them alongside
+    ///   `_relevance_score`.
     #[napi]
-    pub async fn try_new(k: &[f32]) -> Result<Self> {
+    pub async fn try_new(k: &[f32], return_score: Option<String>) -> Result<Self> {
         let k = k
             .first()
             .copied()
@@ -112,8 +118,14 @@ impl RRFReranker {
             })
             .default_error()?;
 
+        let return_score: lancedb::rerankers::ReturnScore = return_score
+            .as_deref()
+            .unwrap_or("relevance")
+            .parse()
+            .map_err(|e: lancedb::error::Error| napi::Error::from_reason(e.to_string()))?;
+
         Ok(Self {
-            inner: lancedb::rerankers::rrf::RRFReranker::new(k),
+            inner: lancedb::rerankers::rrf::RRFReranker::new_with_score(k, return_score),
         })
     }
 

--- a/python/python/tests/test_namespace.py
+++ b/python/python/tests/test_namespace.py
@@ -8,6 +8,7 @@ import shutil
 import pytest
 import pyarrow as pa
 import lancedb
+from lance_namespace.errors import NamespaceNotEmptyError, TableNotFoundError
 
 
 class TestNamespaceConnection:
@@ -130,7 +131,7 @@ class TestNamespaceConnection:
         assert len(list(db.table_names(namespace=["test_ns"]))) == 0
 
         # Should not be able to open dropped table
-        with pytest.raises(RuntimeError):
+        with pytest.raises(TableNotFoundError):
             db.open_table("table1", namespace=["test_ns"])
 
     def test_create_table_with_schema(self):
@@ -340,7 +341,7 @@ class TestNamespaceConnection:
         db.create_table("test_table", schema=schema, namespace=["test_namespace"])
 
         # Try to drop namespace with tables - should fail
-        with pytest.raises(RuntimeError, match="is not empty"):
+        with pytest.raises(NamespaceNotEmptyError):
             db.drop_namespace(["test_namespace"])
 
         # Drop table first

--- a/rust/lancedb/src/rerankers.rs
+++ b/rust/lancedb/src/rerankers.rs
@@ -20,18 +20,23 @@ const RELEVANCE_SCORE: &str = "_relevance_score";
 
 /// Controls which scores are returned in the reranker output.
 ///
-/// - [`ReturnScore::Relevance`]: Only the `_relevance_score` column is kept.
-///   The raw `_distance` and `_score` columns (from vector and FTS search
-///   respectively) are dropped.
-/// - [`ReturnScore::All`]: All score columns are retained alongside the
-///   `_relevance_score`, which is useful for debugging.
+/// - [`ReturnScore::Relevance`]: Default behavior. The output contains
+///   `_relevance_score` alongside whatever score columns were naturally
+///   produced by the merge (typically `_score` from FTS search).
+///   `_distance` is not included because the merge uses the FTS schema as
+///   its base, so the vector `_distance` column is dropped during merging.
+/// - [`ReturnScore::All`]: All raw score columns (`_distance` from vector
+///   search and `_score` from FTS search) are retained alongside
+///   `_relevance_score`. Missing columns are filled with `null` values so
+///   that the two result sets can be concatenated cleanly.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum ReturnScore {
-    /// Return only the `_relevance_score` column (default).
+    /// Return `_relevance_score` and whatever score columns naturally survive
+    /// the merge (default).
     #[default]
     Relevance,
-    /// Return `_relevance_score` plus all original score columns (`_distance`,
-    /// `_score`).
+    /// Return `_relevance_score` plus all original score columns (`_distance`
+    /// and `_score`), filling missing values with `null`.
     All,
 }
 
@@ -106,37 +111,6 @@ pub trait Reranker: std::fmt::Debug + Sync + Send {
         vector_results: RecordBatch,
         fts_results: RecordBatch,
     ) -> Result<RecordBatch>;
-
-    /// Drop the raw `_distance` and `_score` columns from `batch`, keeping
-    /// only the `_relevance_score` produced by the reranker.
-    ///
-    /// Call this at the end of [`Reranker::rerank_hybrid`] when
-    /// `return_score == ReturnScore::Relevance`.
-    fn keep_relevance_score(&self, batch: RecordBatch) -> Result<RecordBatch> {
-        let schema = batch.schema();
-        let columns_to_drop = ["_distance", "_score"];
-        let keep_indices: Vec<usize> = schema
-            .fields()
-            .iter()
-            .enumerate()
-            .filter(|(_, f)| !columns_to_drop.contains(&f.name().as_str()))
-            .map(|(i, _)| i)
-            .collect();
-        let new_schema = arrow_schema::Schema::new(
-            keep_indices
-                .iter()
-                .map(|&i| schema.field(i).clone())
-                .collect::<Vec<_>>(),
-        );
-        let new_columns = keep_indices
-            .iter()
-            .map(|&i| batch.column(i).clone())
-            .collect::<Vec<_>>();
-        Ok(RecordBatch::try_new(
-            std::sync::Arc::new(new_schema),
-            new_columns,
-        )?)
-    }
 
     fn merge_results(
         &self,

--- a/rust/lancedb/src/rerankers.rs
+++ b/rust/lancedb/src/rerankers.rs
@@ -18,6 +18,49 @@ pub mod rrf;
 /// column name for reranker relevance score
 const RELEVANCE_SCORE: &str = "_relevance_score";
 
+/// Controls which scores are returned in the reranker output.
+///
+/// - [`ReturnScore::Relevance`]: Only the `_relevance_score` column is kept.
+///   The raw `_distance` and `_score` columns (from vector and FTS search
+///   respectively) are dropped.
+/// - [`ReturnScore::All`]: All score columns are retained alongside the
+///   `_relevance_score`, which is useful for debugging.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum ReturnScore {
+    /// Return only the `_relevance_score` column (default).
+    #[default]
+    Relevance,
+    /// Return `_relevance_score` plus all original score columns (`_distance`,
+    /// `_score`).
+    All,
+}
+
+impl FromStr for ReturnScore {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "relevance" => Ok(Self::Relevance),
+            "all" => Ok(Self::All),
+            _ => Err(Error::InvalidInput {
+                message: format!(
+                    "invalid return_score value: \"{}\". Expected \"relevance\" or \"all\"",
+                    s
+                ),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for ReturnScore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Relevance => write!(f, "relevance"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum NormalizeMethod {
     Score,
@@ -63,6 +106,37 @@ pub trait Reranker: std::fmt::Debug + Sync + Send {
         vector_results: RecordBatch,
         fts_results: RecordBatch,
     ) -> Result<RecordBatch>;
+
+    /// Drop the raw `_distance` and `_score` columns from `batch`, keeping
+    /// only the `_relevance_score` produced by the reranker.
+    ///
+    /// Call this at the end of [`Reranker::rerank_hybrid`] when
+    /// `return_score == ReturnScore::Relevance`.
+    fn keep_relevance_score(&self, batch: RecordBatch) -> Result<RecordBatch> {
+        let schema = batch.schema();
+        let columns_to_drop = ["_distance", "_score"];
+        let keep_indices: Vec<usize> = schema
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| !columns_to_drop.contains(&f.name().as_str()))
+            .map(|(i, _)| i)
+            .collect();
+        let new_schema = arrow_schema::Schema::new(
+            keep_indices
+                .iter()
+                .map(|&i| schema.field(i).clone())
+                .collect::<Vec<_>>(),
+        );
+        let new_columns = keep_indices
+            .iter()
+            .map(|&i| batch.column(i).clone())
+            .collect::<Vec<_>>();
+        Ok(RecordBatch::try_new(
+            std::sync::Arc::new(new_schema),
+            new_columns,
+        )?)
+    }
 
     fn merge_results(
         &self,

--- a/rust/lancedb/src/rerankers/rrf.rs
+++ b/rust/lancedb/src/rerankers/rrf.rs
@@ -14,31 +14,59 @@ use async_trait::async_trait;
 use lance::dataset::ROW_ID;
 
 use crate::error::{Error, Result};
-use crate::rerankers::{RELEVANCE_SCORE, Reranker};
+use crate::rerankers::{RELEVANCE_SCORE, Reranker, ReturnScore};
 
 /// Reranks the results using Reciprocal Rank Fusion(RRF) algorithm based
 /// on the scores of vector and FTS search.
 ///
+/// # Parameters
+///
+/// - `k`: A constant used in the RRF formula (default `60`). Experiments
+///   indicate that `k = 60` was near-optimal, but the choice is not critical.
+///   See paper: <https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf>
+/// - `return_score`: Controls which score columns appear in the output.
+///   [`ReturnScore::Relevance`] (default) keeps only the `_relevance_score`
+///   column and drops `_distance` / `_score`. [`ReturnScore::All`] retains
+///   every score column, which is useful for debugging.
 #[derive(Debug)]
 pub struct RRFReranker {
     k: f32,
+    return_score: ReturnScore,
 }
 
 impl RRFReranker {
-    /// Create a new RRFReranker
+    /// Create a new [`RRFReranker`] with the given `k` value and
+    /// [`ReturnScore::Relevance`] (drops raw distance / FTS score columns).
     ///
-    /// The parameter k is a constant used in the RRF formula (default is 60).
-    /// Experiments indicate that k = 60 was near-optimal, but that the choice
-    /// is not critical. See paper:
-    /// https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
+    /// The parameter `k` is a constant used in the RRF formula (default is
+    /// `60`). Experiments indicate that `k = 60` was near-optimal, but that
+    /// the choice is not critical. See paper:
+    /// <https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf>
     pub fn new(k: f32) -> Self {
-        Self { k }
+        Self {
+            k,
+            return_score: ReturnScore::Relevance,
+        }
+    }
+
+    /// Create a new [`RRFReranker`] specifying both `k` and `return_score`.
+    ///
+    /// ```
+    /// # use lancedb::rerankers::rrf::RRFReranker;
+    /// # use lancedb::rerankers::ReturnScore;
+    /// let reranker = RRFReranker::new_with_score(60.0, ReturnScore::All);
+    /// ```
+    pub fn new_with_score(k: f32, return_score: ReturnScore) -> Self {
+        Self { k, return_score }
     }
 }
 
 impl Default for RRFReranker {
     fn default() -> Self {
-        Self { k: 60.0 }
+        Self {
+            k: 60.0,
+            return_score: ReturnScore::Relevance,
+        }
     }
 }
 
@@ -145,14 +173,18 @@ impl Reranker for RRFReranker {
 
         let combined_results = RecordBatch::try_new(Arc::new(schema), columns)?;
 
-        Ok(combined_results)
+        if self.return_score == ReturnScore::Relevance {
+            self.keep_relevance_score(combined_results)
+        } else {
+            Ok(combined_results)
+        }
     }
 }
 
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use arrow_array::StringArray;
+    use arrow_array::{Float32Array, StringArray};
 
     #[tokio::test]
     async fn test_rrf_reranker() {
@@ -218,6 +250,116 @@ pub mod test {
         assert_eq!(
             scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
             vec![1.5, 1.0, 0.75, 1.0 / 5.0 + 1.0 / 3.0, 1.0 / 3.0]
+        );
+    }
+
+    /// When `return_score = ReturnScore::Relevance` (default), `_distance` and
+    /// `_score` columns must be dropped from the output.
+    #[tokio::test]
+    async fn test_rrf_return_score_relevance_drops_raw_scores() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
+            Field::new("_score", DataType::Float32, true),
+        ]));
+
+        let vec_results = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["foo", "bar"])),
+                Arc::new(UInt64Array::from(vec![1u64, 2u64])),
+                Arc::new(Float32Array::from(vec![0.1f32, 0.2f32])),
+            ],
+        )
+        .unwrap();
+
+        let fts_results = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["bar", "baz"])),
+                Arc::new(UInt64Array::from(vec![2u64, 3u64])),
+                Arc::new(Float32Array::from(vec![0.9f32, 0.8f32])),
+            ],
+        )
+        .unwrap();
+
+        // default constructor → ReturnScore::Relevance
+        let reranker = RRFReranker::new(1.0);
+        let result = reranker
+            .rerank_hybrid("", vec_results, fts_results)
+            .await
+            .unwrap();
+
+        let schema = result.schema();
+        let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+
+        assert!(
+            !field_names.contains(&"_distance"),
+            "_distance should be dropped: {:?}",
+            field_names
+        );
+        assert!(
+            !field_names.contains(&"_score"),
+            "_score should be dropped: {:?}",
+            field_names
+        );
+        assert!(
+            field_names.contains(&RELEVANCE_SCORE),
+            "_relevance_score should be present: {:?}",
+            field_names
+        );
+    }
+
+    /// When `return_score = ReturnScore::All`, raw score columns
+    /// must be retained in the output alongside `_relevance_score`.
+    #[tokio::test]
+    async fn test_rrf_return_score_all_keeps_raw_scores() {
+        // Both vector and FTS results share the same schema so that merge_results
+        // preserves all columns without needing schema promotion.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
+            Field::new("_score", DataType::Float32, true),
+        ]));
+
+        let vec_results = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["foo", "bar"])),
+                Arc::new(UInt64Array::from(vec![1u64, 2u64])),
+                Arc::new(Float32Array::from(vec![0.1f32, 0.2f32])),
+            ],
+        )
+        .unwrap();
+
+        let fts_results = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["bar", "baz"])),
+                Arc::new(UInt64Array::from(vec![2u64, 3u64])),
+                Arc::new(Float32Array::from(vec![0.9f32, 0.8f32])),
+            ],
+        )
+        .unwrap();
+
+        let reranker = RRFReranker::new_with_score(1.0, ReturnScore::All);
+        let result = reranker
+            .rerank_hybrid("", vec_results, fts_results)
+            .await
+            .unwrap();
+
+        let schema = result.schema();
+        let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+
+        assert!(
+            field_names.contains(&"_score"),
+            "_score should be kept: {:?}",
+            field_names
+        );
+        assert!(
+            field_names.contains(&RELEVANCE_SCORE),
+            "_relevance_score should be present: {:?}",
+            field_names
         );
     }
 }

--- a/rust/lancedb/src/rerankers/rrf.rs
+++ b/rust/lancedb/src/rerankers/rrf.rs
@@ -25,9 +25,13 @@ use crate::rerankers::{RELEVANCE_SCORE, Reranker, ReturnScore};
 ///   indicate that `k = 60` was near-optimal, but the choice is not critical.
 ///   See paper: <https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf>
 /// - `return_score`: Controls which score columns appear in the output.
-///   [`ReturnScore::Relevance`] (default) keeps only the `_relevance_score`
-///   column and drops `_distance` / `_score`. [`ReturnScore::All`] retains
-///   every score column, which is useful for debugging.
+///   - [`ReturnScore::Relevance`] (default): preserves the original merge
+///     behavior — the output contains `_relevance_score` and `_score` (FTS),
+///     but not `_distance` (vector), because the merge uses the FTS schema
+///     as its base.
+///   - [`ReturnScore::All`]: retains every raw score column. Missing columns
+///     (`_distance` for FTS rows, `_score` for vector-only rows) are filled
+///     with `null` so both result sets can be concatenated.
 #[derive(Debug)]
 pub struct RRFReranker {
     k: f32,
@@ -36,7 +40,8 @@ pub struct RRFReranker {
 
 impl RRFReranker {
     /// Create a new [`RRFReranker`] with the given `k` value and
-    /// [`ReturnScore::Relevance`] (drops raw distance / FTS score columns).
+    /// [`ReturnScore::Relevance`] (default behavior, preserves original merge
+    /// output).
     ///
     /// The parameter `k` is a constant used in the RRF formula (default is
     /// `60`). Experiments indicate that `k = 60` was near-optimal, but that
@@ -58,6 +63,68 @@ impl RRFReranker {
     /// ```
     pub fn new_with_score(k: f32, return_score: ReturnScore) -> Self {
         Self { k, return_score }
+    }
+
+    /// Merge vector and FTS results keeping all score columns.
+    ///
+    /// Before concatenating, each side is padded with null-filled columns for
+    /// scores it doesn't already carry:
+    /// - vector results get a null `_score` column if absent
+    /// - FTS results get a null `_distance` column if absent
+    ///
+    /// This ensures both `_distance` and `_score` survive the merge.
+    fn merge_results_all_scores(
+        &self,
+        vector_results: RecordBatch,
+        fts_results: RecordBatch,
+    ) -> Result<RecordBatch> {
+        use arrow_array::new_null_array;
+        use arrow_schema::SchemaBuilder;
+
+        let add_null_column =
+            |batch: &RecordBatch, col_name: &str, dtype: DataType| -> Result<RecordBatch> {
+                if batch.schema().column_with_name(col_name).is_some() {
+                    return Ok(batch.clone());
+                }
+                let null_col = new_null_array(&dtype, batch.num_rows());
+                let mut builder = SchemaBuilder::from(batch.schema().fields());
+                builder.push(Arc::new(Field::new(col_name, dtype, true)));
+                let new_schema = Arc::new(builder.finish());
+                let mut cols = batch.columns().to_vec();
+                cols.push(null_col);
+                Ok(RecordBatch::try_new(new_schema, cols)?)
+            };
+
+        let vector_results = add_null_column(&vector_results, "_score", DataType::Float32)?;
+        let fts_results = add_null_column(&fts_results, "_distance", DataType::Float32)?;
+
+        // Reorder fts columns to match vector schema so concat_batches is happy
+        let vec_schema = vector_results.schema();
+        let fts_reordered = {
+            let indices: std::result::Result<Vec<usize>, _> = vec_schema
+                .fields()
+                .iter()
+                .map(|f| {
+                    fts_results
+                        .schema()
+                        .index_of(f.name())
+                        .map_err(|_| Error::InvalidInput {
+                            message: format!(
+                                "column '{}' missing from fts_results after padding",
+                                f.name()
+                            ),
+                        })
+                })
+                .collect();
+            let indices = indices?;
+            let cols: Vec<_> = indices
+                .iter()
+                .map(|&i| fts_results.column(i).clone())
+                .collect();
+            RecordBatch::try_new(vec_schema.clone(), cols)?
+        };
+
+        self.merge_results(vector_results, fts_reordered)
     }
 }
 
@@ -129,7 +196,13 @@ impl Reranker for RRFReranker {
             .enumerate()
             .for_each(&mut update_score_map);
 
-        let combined_results = self.merge_results(vector_results, fts_results)?;
+        // For ReturnScore::All, merge while preserving all score columns.
+        // For ReturnScore::Relevance, use the original merge (FTS schema as base).
+        let combined_results = if self.return_score == ReturnScore::All {
+            self.merge_results_all_scores(vector_results, fts_results)?
+        } else {
+            self.merge_results(vector_results, fts_results)?
+        };
 
         let combined_row_ids: UInt64Array =
             downcast_array(combined_results.column_by_name(ROW_ID).unwrap());
@@ -173,11 +246,7 @@ impl Reranker for RRFReranker {
 
         let combined_results = RecordBatch::try_new(Arc::new(schema), columns)?;
 
-        if self.return_score == ReturnScore::Relevance {
-            self.keep_relevance_score(combined_results)
-        } else {
-            Ok(combined_results)
-        }
+        Ok(combined_results)
     }
 }
 
@@ -253,18 +322,24 @@ pub mod test {
         );
     }
 
-    /// When `return_score = ReturnScore::Relevance` (default), `_distance` and
-    /// `_score` columns must be dropped from the output.
+    /// `ReturnScore::Relevance` (default) preserves the original merge behavior:
+    /// `_score` (FTS) is kept, `_distance` is not present (FTS schema is used as
+    /// the merge base so the vector `_distance` column is dropped naturally).
     #[tokio::test]
-    async fn test_rrf_return_score_relevance_drops_raw_scores() {
-        let schema = Arc::new(Schema::new(vec![
+    async fn test_rrf_return_score_relevance_preserves_original_behavior() {
+        let vec_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
+            Field::new("_distance", DataType::Float32, true),
+        ]));
+        let fts_schema = Arc::new(Schema::new(vec![
             Field::new("name", DataType::Utf8, false),
             Field::new(ROW_ID, DataType::UInt64, false),
             Field::new("_score", DataType::Float32, true),
         ]));
 
         let vec_results = RecordBatch::try_new(
-            schema.clone(),
+            vec_schema,
             vec![
                 Arc::new(StringArray::from(vec!["foo", "bar"])),
                 Arc::new(UInt64Array::from(vec![1u64, 2u64])),
@@ -274,7 +349,7 @@ pub mod test {
         .unwrap();
 
         let fts_results = RecordBatch::try_new(
-            schema.clone(),
+            fts_schema,
             vec![
                 Arc::new(StringArray::from(vec!["bar", "baz"])),
                 Arc::new(UInt64Array::from(vec![2u64, 3u64])),
@@ -283,7 +358,7 @@ pub mod test {
         )
         .unwrap();
 
-        // default constructor → ReturnScore::Relevance
+        // default constructor → ReturnScore::Relevance = no extra processing
         let reranker = RRFReranker::new(1.0);
         let result = reranker
             .rerank_hybrid("", vec_results, fts_results)
@@ -293,14 +368,15 @@ pub mod test {
         let schema = result.schema();
         let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
 
+        // original behavior: _score survives, _distance is dropped by merge
         assert!(
-            !field_names.contains(&"_distance"),
-            "_distance should be dropped: {:?}",
+            field_names.contains(&"_score"),
+            "_score should be present: {:?}",
             field_names
         );
         assert!(
-            !field_names.contains(&"_score"),
-            "_score should be dropped: {:?}",
+            !field_names.contains(&"_distance"),
+            "_distance should not be present (original behavior): {:?}",
             field_names
         );
         assert!(
@@ -310,20 +386,23 @@ pub mod test {
         );
     }
 
-    /// When `return_score = ReturnScore::All`, raw score columns
-    /// must be retained in the output alongside `_relevance_score`.
+    /// `ReturnScore::All` retains both `_distance` (vector) and `_score` (FTS)
+    /// by padding missing columns with nulls before merging.
     #[tokio::test]
-    async fn test_rrf_return_score_all_keeps_raw_scores() {
-        // Both vector and FTS results share the same schema so that merge_results
-        // preserves all columns without needing schema promotion.
-        let schema = Arc::new(Schema::new(vec![
+    async fn test_rrf_return_score_all_keeps_both_raw_scores() {
+        let vec_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
+            Field::new("_distance", DataType::Float32, true),
+        ]));
+        let fts_schema = Arc::new(Schema::new(vec![
             Field::new("name", DataType::Utf8, false),
             Field::new(ROW_ID, DataType::UInt64, false),
             Field::new("_score", DataType::Float32, true),
         ]));
 
         let vec_results = RecordBatch::try_new(
-            schema.clone(),
+            vec_schema,
             vec![
                 Arc::new(StringArray::from(vec!["foo", "bar"])),
                 Arc::new(UInt64Array::from(vec![1u64, 2u64])),
@@ -333,7 +412,7 @@ pub mod test {
         .unwrap();
 
         let fts_results = RecordBatch::try_new(
-            schema.clone(),
+            fts_schema,
             vec![
                 Arc::new(StringArray::from(vec!["bar", "baz"])),
                 Arc::new(UInt64Array::from(vec![2u64, 3u64])),
@@ -352,8 +431,13 @@ pub mod test {
         let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
 
         assert!(
+            field_names.contains(&"_distance"),
+            "_distance should be present: {:?}",
+            field_names
+        );
+        assert!(
             field_names.contains(&"_score"),
-            "_score should be kept: {:?}",
+            "_score should be present: {:?}",
             field_names
         );
         assert!(


### PR DESCRIPTION
This pull request enhances the Reciprocal Rank Fusion (RRF) reranker by introducing a new option to control which score columns are included in the output. Users can now choose to retain all raw score columns (`_distance` from vector search and `_score` from full-text search) alongside the computed `_relevance_score`, which is particularly useful for debugging and analysis. The changes include updates to the Rust core, Node.js bindings, and comprehensive tests to ensure correct behavior.

**Feature: Configurable score columns in RRF reranker output**
- Added a new `ReturnScore` enum (`"relevance"` or `"all"`) to control which score columns (`_distance`, `_score`, `_relevance_score`) appear in the RRF reranker output. The default `"relevance"` preserves existing behavior, while `"all"` retains all score columns, filling missing values with `null` for seamless merging. [[1]](diffhunk://#diff-b843105c0a1829f0af67a462470f4cd98d5a794f078cb79f76fd265dcf69e118R21-R68) [[2]](diffhunk://#diff-4e1cfb204ba48a2a528638ea505e3dfeae42e622f590b86c623f72e7a2543a44L17-R136) [[3]](diffhunk://#diff-4e1cfb204ba48a2a528638ea505e3dfeae42e622f590b86c623f72e7a2543a44L104-R205)

**API and Documentation Updates**
- Extended the `RRFReranker` constructors in both Rust and Node.js to accept the new `returnScore`/`return_score` parameter, with updated documentation explaining the options and their effects. [[1]](diffhunk://#diff-a5bde82cdc994b27a345fbbe56bf6d11d3b79824faa3b0965313f797ac8547d0R11-R19) [[2]](diffhunk://#diff-a5bde82cdc994b27a345fbbe56bf6d11d3b79824faa3b0965313f797ac8547d0L21-R35) [[3]](diffhunk://#diff-2c03d561c0edd045b3cf1740a1e21cae24fc9c9559887a268416dab89b9b204cR105-R112) [[4]](diffhunk://#diff-2c03d561c0edd045b3cf1740a1e21cae24fc9c9559887a268416dab89b9b204cR121-R128)

**Implementation and Testing**
- Implemented logic in Rust to merge result sets while preserving all relevant score columns when requested, including padding missing columns with `null` and ensuring schemas are compatible for concatenation.
- Added comprehensive tests in both Rust and Node.js to verify that both modes (`"relevance"` and `"all"`) behave as expected, including schema checks for the presence or absence of score columns. [[1]](diffhunk://#diff-4e1cfb204ba48a2a528638ea505e3dfeae42e622f590b86c623f72e7a2543a44L155-R256) [[2]](diffhunk://#diff-4e1cfb204ba48a2a528638ea505e3dfeae42e622f590b86c623f72e7a2543a44R324-R448) [[3]](diffhunk://#diff-971fe08df20eaf8ea3f2475aca9cb81f74efdbbd3efc038ec2d3f6d8965b1420R79-R117)