### PR TITLE
fix(test): add --experimental-vm-modules for AWS SDK dynamic import compatibility

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -86,7 +86,8 @@
     "lint": "biome check . && biome format .",
     "lint-fix": "biome check --write . && biome format --write .",
     "prepublishOnly": "napi prepublish -t npm",
-    "test": "jest --verbose",
+    "pretest": "echo 'NOTE: --experimental-vm-modules is required as a workaround for @smithy/middleware-retry>=4.4.43 using dynamic import() in CJS builds (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG). Revert to plain jest once upstream smithy-typescript fixes CJS dynamic import usage.'",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --verbose",
     "integration": "S3_TEST=1 npm run test",
     "universal": "napi universalize",
     "version": "napi version"


### PR DESCRIPTION
## Summary

- `@smithy/middleware-retry>=4.4.43` introduced dynamic `import()` calls in its CJS build
- Jest's VM sandbox does not support dynamic imports without `--experimental-vm-modules`, causing `s3_integration.test.ts` to fail with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`
- Updated `test` script to run Jest via `node --experimental-vm-modules`, fixing the issue
- Added `pretest` echo as a reminder that this is a temporary workaround — revert to plain `jest` once upstream [smithy-typescript](https://github.com/smithy-lang/smithy-typescript) fixes CJS dynamic import usage

## Test plan

- [ ] CI: `Linux (NodeJS 20)` and `Linux (NodeJS 18)` s3_integration tests should pass
- [ ] Existing tests should not be affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)