### PR TITLE
feat(ci): simplify workflows for fork

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,6 @@
 name: Deploy docs to Pages
 
 on:
-  push:
-    branches: ["main"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -13,16 +13,7 @@
 name: Build Java LanceDB Core
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - java/**
-      - .github/workflows/java.yml
-  pull_request:
-    paths:
-      - java/**
-      - .github/workflows/java.yml
+  workflow_dispatch:
 
 jobs:
   build-java:

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -1,8 +1,5 @@
 name: Check license headers
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - rust/**

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,9 +1,6 @@
 name: NodeJS (NAPI)
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - Cargo.toml

--- a/.github/workflows/npm-github-packages-publish.yml
+++ b/.github/workflows/npm-github-packages-publish.yml
@@ -66,7 +66,7 @@ jobs:
               apt-get install -y protobuf-compiler pkg-config &&
               export TARGET_CC=clang TARGET_CXX=clang++
           - target: x86_64-unknown-linux-musl
-            host: ubuntu-2404-8x-x64
+            host: ubuntu-24.04
             features: fp16kernels
             pre_build: |-
               set -e &&
@@ -75,7 +75,7 @@ jobs:
               rustup target add x86_64-unknown-linux-musl &&
               export EXTRA_ARGS="-x"
           - target: aarch64-unknown-linux-gnu
-            host: ubuntu-2404-8x-x64
+            host: ubuntu-24.04
             # https://github.com/napi-rs/napi-rs/blob/main/debian-aarch64.Dockerfile
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             features: "fp16kernels"
@@ -87,7 +87,7 @@ jobs:
               export CFLAGS="$CFLAGS -DAT_HWCAP2=26" &&
               rustup target add aarch64-unknown-linux-gnu
           - target: aarch64-unknown-linux-musl
-            host: ubuntu-2404-8x-x64
+            host: ubuntu-24.04
             features: ","
             pre_build: |-
               set -e &&

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,20 +1,7 @@
 name: Python
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    paths:
-      - Cargo.toml
-      - Cargo.lock
-      - python/**
-      - rust/**
-      - .github/workflows/python.yml
-      - .github/workflows/build_linux_wheel/**
-      - .github/workflows/build_mac_wheel/**
-      - .github/workflows/build_windows_wheel/**
-      - .github/workflows/run_tests/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,9 +1,6 @@
 name: Rust
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - Cargo.toml


### PR DESCRIPTION
## Summary

- **On PR**: only run Rust and NodeJS checks; Python CI no longer triggers automatically
- **On merge to main**: only run the GitHub Packages publish workflow
- **Runners**: replace all custom `ubuntu-2404-8x-x64` runners (upstream-only) with standard `ubuntu-24.04`

## Changes

| Workflow | Change |
|---------|--------|
| `rust.yml` | Remove push-to-main trigger; keep PR checks only |
| `nodejs.yml` | Remove push-to-main trigger; keep PR checks only |
| `python.yml` | Disable auto-triggers (manual `workflow_dispatch` only) |
| `docs.yml` | Remove push-to-main trigger (keep `workflow_dispatch`) |
| `java.yml` | Disable auto-triggers (manual `workflow_dispatch` only) |
| `license-header-check.yml` | Remove push-to-main; keep PR checks |
| `npm-github-packages-publish.yml` | Keep push-to-main; replace 3x `ubuntu-2404-8x-x64` with `ubuntu-24.04` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)