### PR TITLE
ci: pass GITHUB_TOKEN to publish step for napi prepublish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -409,6 +409,7 @@ jobs:
           fi
           npm publish $ARGS
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   report-failure:
     name: Report Workflow Failure


### PR DESCRIPTION
The prepublishOnly hook runs `napi prepublish -t npm` which tries to create a GitHub Release. Without GITHUB_TOKEN it fails with 401.