### PR TITLE
feat: add performance profiling and observability support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,7 +948,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -1047,6 +1069,53 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1226,7 +1295,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2779,7 +2848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -2791,7 +2859,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "jiff",
  "log",
 ]
 
@@ -3609,6 +3676,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3648,6 +3716,19 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4104,7 +4185,7 @@ dependencies = [
  "object_store",
  "permutation",
  "pin-project",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "rand 0.9.2",
  "roaring",
@@ -4177,7 +4258,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "pin-project",
- "prost",
+ "prost 0.14.3",
  "rand 0.9.2",
  "roaring",
  "serde_json",
@@ -4214,7 +4295,7 @@ dependencies = [
  "lance-datagen",
  "log",
  "pin-project",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "snafu 0.9.0",
  "tokio",
@@ -4266,7 +4347,7 @@ dependencies = [
  "log",
  "lz4",
  "num-traits",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "rand 0.9.2",
@@ -4303,7 +4384,7 @@ dependencies = [
  "log",
  "num-traits",
  "object_store",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "snafu 0.9.0",
@@ -4356,7 +4437,7 @@ dependencies = [
  "ndarray",
  "num-traits",
  "object_store",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "rand 0.9.2",
@@ -4411,7 +4492,7 @@ dependencies = [
  "opendal",
  "path_abs",
  "pin-project",
- "prost",
+ "prost 0.14.3",
  "rand 0.9.2",
  "serde",
  "snafu 0.9.0",
@@ -4517,7 +4598,7 @@ dependencies = [
  "lance-io",
  "log",
  "object_store",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "rand 0.9.2",
@@ -4599,9 +4680,12 @@ dependencies = [
  "lance-table",
  "lance-testing",
  "lazy_static",
- "log",
  "num-traits",
  "object_store",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "pin-project",
  "polars",
  "polars-arrow",
@@ -4618,6 +4702,9 @@ dependencies = [
  "test-log",
  "tokenizers",
  "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "url",
  "uuid",
  "walkdir",
@@ -4634,15 +4721,17 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "aws-lc-sys",
- "env_logger",
  "futures",
  "half",
  "lancedb",
- "log",
  "lzma-sys",
  "napi",
  "napi-build",
  "napi-derive",
+ "opentelemetry",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4890,6 +4979,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
@@ -5424,6 +5519,100 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c513c7af3bec30113f3d4620134ff923295f1e9c580fda2b8abe0831f925ddc0"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
 
 [[package]]
 name = "option-ext"
@@ -6160,12 +6349,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -6174,17 +6373,30 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "regex",
  "syn 2.0.117",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6194,7 +6406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6206,7 +6418,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -6659,6 +6871,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.13",
@@ -6685,7 +6898,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -7365,7 +7578,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7377,7 +7590,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8141,6 +8354,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8173,7 +8436,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -8234,6 +8497,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8243,12 +8534,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,13 @@ datafusion-physical-plan = "52.1"
 datafusion-physical-expr = "52.1"
 datafusion-sql = "52.1"
 env_logger = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "json", "env-filter", "registry"] }
+tracing-opentelemetry = "0.29"
+opentelemetry = "0.28"
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "http-proto", "logs", "metrics", "trace"] }
+opentelemetry-appender-tracing = "0.28"
 half = { "version" = "2.7.1", default-features = false, features = [
     "num-traits",
 ] }

--- a/docs/src/js/functions/initProfiling.md
+++ b/docs/src/js/functions/initProfiling.md
@@ -15,7 +15,9 @@ Initialize OTLP profiling for traces, metrics, and logs.
 Sets up the OpenTelemetry pipeline to export telemetry data to
 an OTLP-compatible collector (e.g. Grafana Alloy, OpenTelemetry Collector).
 
-Must be called before any LanceDB operations to capture all spans.
+Can be called at any time — the global subscriber installed at module
+load supports hot-reloading, so there is no "must call before any
+LanceDB operations" constraint.
 
 Requires the native library to be built with the `profiling-otlp` feature.
 

--- a/docs/src/js/functions/initProfiling.md
+++ b/docs/src/js/functions/initProfiling.md
@@ -1,0 +1,40 @@
+[**@delta-ai/lancedb**](../README.md) • **Docs**
+
+***
+
+[@delta-ai/lancedb](../globals.md) / initProfiling
+
+# Function: initProfiling()
+
+```ts
+function initProfiling(options?): void
+```
+
+Initialize OTLP profiling for traces, metrics, and logs.
+
+Sets up the OpenTelemetry pipeline to export telemetry data to
+an OTLP-compatible collector (e.g. Grafana Alloy, OpenTelemetry Collector).
+
+Must be called before any LanceDB operations to capture all spans.
+
+Requires the native library to be built with the `profiling-otlp` feature.
+
+## Parameters
+
+* **options?**: [`ProfilingOptions`](../interfaces/ProfilingOptions.md)
+    Optional configuration for the OTLP endpoint.
+
+## Returns
+
+`void`
+
+## Example
+
+```ts
+import { initProfiling } from "lancedb";
+
+initProfiling({
+  otlpEndpoint: "http://localhost:4318",
+  serviceName: "my-app",
+});
+```

--- a/docs/src/js/functions/withTraceparent.md
+++ b/docs/src/js/functions/withTraceparent.md
@@ -1,0 +1,40 @@
+[**@delta-ai/lancedb**](../README.md) • **Docs**
+
+***
+
+[@delta-ai/lancedb](../globals.md) / withTraceparent
+
+# Function: withTraceparent()
+
+```ts
+function withTraceparent<T>(traceparent, fn): T
+```
+
+Run a function with a specific W3C traceparent string.
+
+Any LanceDB operations called within `fn` will use this traceparent
+to link Rust-side tracing spans to the caller's trace.
+
+## Type Parameters
+
+• **T**
+
+## Parameters
+
+* **traceparent**: `undefined` \| `string`
+
+* **fn**
+
+## Returns
+
+`T`
+
+## Example
+
+```ts
+import { withTraceparent } from "@delta-ai/lancedb";
+
+// Inside a Hono / Express / Koa handler:
+const tp = req.headers.get("traceparent");
+const results = await withTraceparent(tp, () => table.query().limit(10).toArray());
+```

--- a/docs/src/js/globals.md
+++ b/docs/src/js/globals.md
@@ -68,6 +68,7 @@
 - [OpenTableOptions](interfaces/OpenTableOptions.md)
 - [OptimizeOptions](interfaces/OptimizeOptions.md)
 - [OptimizeStats](interfaces/OptimizeStats.md)
+- [ProfilingOptions](interfaces/ProfilingOptions.md)
 - [QueryExecutionOptions](interfaces/QueryExecutionOptions.md)
 - [RemovalStats](interfaces/RemovalStats.md)
 - [ShuffleOptions](interfaces/ShuffleOptions.md)
@@ -98,6 +99,8 @@
 
 - [RecordBatchIterator](functions/RecordBatchIterator.md)
 - [connect](functions/connect.md)
+- [initProfiling](functions/initProfiling.md)
 - [makeArrowTable](functions/makeArrowTable.md)
 - [packBits](functions/packBits.md)
 - [permutationBuilder](functions/permutationBuilder.md)
+- [withTraceparent](functions/withTraceparent.md)

--- a/docs/src/js/interfaces/ProfilingOptions.md
+++ b/docs/src/js/interfaces/ProfilingOptions.md
@@ -1,0 +1,41 @@
+[**@delta-ai/lancedb**](../README.md) • **Docs**
+
+***
+
+[@delta-ai/lancedb](../globals.md) / ProfilingOptions
+
+# Interface: ProfilingOptions
+
+Options for configuring OTLP profiling export.
+
+## Properties
+
+### otlpEndpoint?
+
+```ts
+optional otlpEndpoint: string;
+```
+
+The OTLP collector endpoint (e.g. "http://localhost:4318").
+Falls back to OTEL_EXPORTER_OTLP_ENDPOINT env var.
+
+***
+
+### protocol?
+
+```ts
+optional protocol: string;
+```
+
+Transport protocol: "http" (default) or "grpc".
+
+***
+
+### serviceName?
+
+```ts
+optional serviceName: string;
+```
+
+The service name for telemetry (defaults to "lancedb").
+Falls back to OTEL_SERVICE_NAME env var.

--- a/docs/src/performance-profiling-design.md
+++ b/docs/src/performance-profiling-design.md
@@ -1,0 +1,293 @@
+# Performance Profiling Design
+
+> Status: Draft
+> Date: 2026-04-08
+> Author: TheDeltaLab
+
+---
+
+## 1. Current State
+
+### 1.1 Logging Framework
+
+LanceDB currently uses `log` (0.4) + `env_logger` (0.11) as its logging solution. A small
+number of `log::warn!` / `log::debug!` / `log::info!` calls are scattered throughout the
+codebase, primarily for warnings and debugging, with no performance measurement. The Node.js
+bindings control the log level via the `LANCEDB_LOG` environment variable (defaults to `warn`).
+
+**Not used:** `tracing` crate, `#[instrument]` annotations, spans, or structured events.
+
+### 1.2 Underlying Lance Library
+
+Lance (v5.0.0-beta.5) already depends on `tracing` (0.1), which means:
+
+- Internal spans/events in Lance can already be collected by an upstream subscriber
+- LanceDB can directly reuse the `tracing` ecosystem without introducing additional bridging layers
+- `tracing` is natively compatible with the `log` crate (`tracing` provides a `log` feature for automatic bridging)
+
+### 1.3 Existing Performance Measurement Capabilities
+
+| Module | File | Capability |
+|--------|------|------------|
+| I/O Statistics | `rust/lancedb/src/io/object_store/io_tracking.rs` | `IoTrackingStore` wraps `ObjectStore`, accumulating read/write IOPS and bytes |
+| Write Progress | `rust/lancedb/src/table/write_progress.rs` | `WriteProgressTracker` reports row count, bytes, and elapsed time via callbacks |
+| Optimization Stats | `rust/lancedb/src/table/optimize.rs` | `OptimizeStats` aggregates compaction and removal metrics |
+| Query Timeout | `rust/lancedb/src/utils/mod.rs` | `TimeoutStream` adds timeout control to query streams |
+
+These mechanisms are independent of each other, with no unified collection or export channel.
+
+### 1.4 Query Execution Path Overview
+
+```
+User API (Table::query())
+  → Query builder (QueryBase / ExecutableQuery trait)
+    → BaseTable::query() / BaseTable::create_plan()
+      → Lance dataset scanner
+        → ObjectStore (possibly wrapped by IoTrackingStore)
+          → Local files / Cloud storage
+```
+
+Key traits:
+
+- `BaseTable` (`rust/lancedb/src/table.rs:232`): defines `query()` / `create_plan()`
+- `ExecutableQuery` (`rust/lancedb/src/query.rs:621`): defines `execute()` / `create_plan()`
+- `NativeTable`: local table implementation
+
+---
+
+## 2. Goals
+
+1. **Function call tracing**: Record key function invocations and their duration (query, index, write, optimize paths)
+2. **File I/O tracing**: Record each I/O operation at the ObjectStore layer and its duration (read/write/list, etc.)
+3. **OpenTelemetry support**: Allow users to export traces/metrics to OTLP-compatible backends
+4. **Low coupling**: Do not intrude on existing business logic; can be fully removed via feature flags
+
+---
+
+## 3. Scope
+
+### 3.1 In-Scope
+
+- Introduce the `tracing` crate to replace (and bridge) the `log` crate
+- Add `#[instrument]` annotations to key functions
+- Enhance `IoTrackingStore` to emit `tracing` spans/events (with duration)
+- Provide `tracing-opentelemetry` integration as an optional feature
+- Provide a built-in simple profiling subscriber (e.g., JSON log output)
+- Expose profiling control interfaces in the Node.js bindings (enable/disable, configure OTLP endpoint)
+
+### 3.2 Out-of-Scope
+
+- Instrumentation changes inside the Lance library (maintained by upstream)
+- Real-time dashboards or UI visualization
+- Custom metrics (e.g., histograms, counters) — first phase focuses on tracing only
+- CPU profiling (e.g., pprof integration)
+- Memory allocation tracking
+
+---
+
+## 4. Design Principles
+
+1. **Zero-cost abstraction**: When profiling is not enabled, tracing macros compile to no-ops or extremely low-overhead calls. `tracing` crate spans have nanosecond-level overhead when no subscriber is active.
+2. **Feature-gated**: All profiling dependencies (`tracing-subscriber`, `tracing-opentelemetry`, `opentelemetry-otlp`, etc.) are controlled via cargo features, with no impact on default binary size.
+3. **Decorator / Wrapper pattern**: Inject tracing logic by wrapping existing components (e.g., `ObjectStore`) rather than modifying their internals, minimizing changes to existing code.
+4. **Structured data**: All spans and events carry structured fields (table name, query type, bytes read, etc.) rather than plain text messages, facilitating downstream analysis.
+5. **User-controllable**: Profiling enable/disable, sampling rate, and export targets are all configurable at runtime without requiring recompilation.
+
+---
+
+## 5. Design Considerations
+
+### 5.1 Approach Selection: Why `tracing` + OpenTelemetry
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **`tracing` ecosystem** | Rust ecosystem standard; Lance already depends on it; zero-cost; async-friendly; rich subscriber ecosystem | Requires learning the span model |
+| Custom profiling framework | Full control | Reinventing the wheel; isolated ecosystem; high maintenance cost |
+| `metrics` crate | Focused on metrics | No trace support; lacks call chain context |
+| Pure `log` enhancement | Minimal changes | Cannot record duration; no call chains; no OTLP support |
+
+**Conclusion**: `tracing` + `tracing-opentelemetry` is the most reasonable choice.
+
+### 5.2 Instrumentation Layers
+
+A layered instrumentation strategy, from coarse to fine:
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Layer 1: Public API entry points                     │
+│   Table::query(), Table::add(), Table::delete()      │
+│   → #[instrument] annotations                        │
+├──────────────────────────────────────────────────────┤
+│ Layer 2: Internal critical paths                     │
+│   BaseTable::query(), create_plan(),                 │
+│   index creation, optimize                           │
+│   → #[instrument] annotations                        │
+├──────────────────────────────────────────────────────┤
+│ Layer 3: I/O operations                              │
+│   IoTrackingStore's ObjectStore implementation        │
+│   → Emit spans with duration for each get/put/list   │
+├──────────────────────────────────────────────────────┤
+│ Layer 4: Lance internals (provided by upstream)      │
+│   Dataset scan, index search, etc.                   │
+│   → Existing tracing spans, automatically collected  │
+└──────────────────────────────────────────────────────┘
+```
+
+### 5.3 `IoTrackingStore` Enhancement
+
+Currently `IoTrackingStore` only accumulates statistics. The enhancement direction:
+
+```rust
+// Before
+async fn get(&self, location: &Path) -> OSResult<GetResult> {
+    let result = self.target.get(location).await;
+    if let Ok(result) = &result {
+        self.record_read(num_bytes);
+    }
+    result
+}
+
+// After
+async fn get(&self, location: &Path) -> OSResult<GetResult> {
+    let span = tracing::info_span!("object_store.get",
+        path = %location,
+        bytes = tracing::field::Empty,
+    );
+    let _guard = span.enter();
+    let result = self.target.get(location).await;
+    if let Ok(result) = &result {
+        let num_bytes = result.range.end - result.range.start;
+        span.record("bytes", num_bytes);
+        self.record_read(num_bytes);
+    }
+    result
+}
+```
+
+`tracing` spans automatically record entry and exit times; subscribers can compute duration from this. The existing `IoStats` cumulative statistics remain unchanged — both coexist.
+
+### 5.4 Feature Flag Design
+
+```toml
+# rust/lancedb/Cargo.toml
+[features]
+default = []
+profiling = ["tracing/attributes", "tracing-subscriber"]
+profiling-otlp = [
+    "profiling",
+    "tracing-opentelemetry",
+    "opentelemetry",
+    "opentelemetry_sdk",
+    "opentelemetry-otlp",
+]
+```
+
+- `profiling`: Enables `#[instrument]` and basic subscribers (log/JSON output)
+- `profiling-otlp`: Adds OTLP export capability
+
+**When features are not enabled**: `#[instrument]` degrades to an empty attribute via conditional compilation; tracing macros produce only nanosecond-level overhead without a subscriber.
+
+### 5.5 Conditional `#[instrument]` Usage Strategy
+
+To avoid unnecessary intrusion on core code paths, `#[instrument]` is only added to:
+
+1. **Public API methods** (`Table`'s `query`, `add`, `delete`, `optimize`, etc.)
+2. **Key trait implementation methods** (`BaseTable::query`, `BaseTable::create_plan`)
+3. **I/O wrapper methods** (`IoTrackingStore`'s `ObjectStore` methods)
+
+Internal helper functions are not instrumented to avoid noise and performance impact.
+
+### 5.6 User Integration
+
+#### Rust Users
+
+```rust
+use lancedb::profiling;
+
+// Option 1: Use the built-in JSON subscriber
+profiling::init_json_subscriber();
+
+// Option 2: Use OTLP export
+profiling::init_otlp_subscriber("http://localhost:4317");
+
+// Option 3: User-built subscriber (full control)
+use tracing_subscriber::prelude::*;
+let otel_layer = /* custom OpenTelemetry layer */;
+tracing_subscriber::registry()
+    .with(otel_layer)
+    .init();
+```
+
+#### Node.js Users
+
+```typescript
+import { initProfiling } from 'vectordb';
+
+// Enable OTLP export
+initProfiling({ otlpEndpoint: 'http://localhost:4317' });
+
+// Or JSON log output
+initProfiling({ format: 'json' });
+```
+
+### 5.7 Span Naming Convention
+
+Following OpenTelemetry semantic convention style:
+
+| Span Name | Structured Fields |
+|-----------|-------------------|
+| `lancedb.table.query` | `table`, `query_type`, `top_k`, `filter` |
+| `lancedb.table.add` | `table`, `num_rows`, `mode` |
+| `lancedb.table.delete` | `table`, `predicate` |
+| `lancedb.table.optimize` | `table`, `action` |
+| `lancedb.index.create` | `table`, `index_type`, `columns` |
+| `lancedb.io.get` | `path`, `bytes` |
+| `lancedb.io.put` | `path`, `bytes` |
+| `lancedb.io.list` | `prefix` |
+
+### 5.8 Handling Existing `log` Macros
+
+`tracing` provides a `log` feature (enabled by default) that automatically converts
+`log::info!` and similar calls into tracing events. Therefore, replace `log::*` with
+`tracing::*` to gain structured field support.
+
+---
+
+## 6. Change Summary
+
+### Phase 1: Infrastructure (low risk, ~5 files)
+
+| Change | File |
+|--------|------|
+| Add workspace dependencies | `Cargo.toml` |
+| Add feature flags and dependencies | `rust/lancedb/Cargo.toml` |
+| Create profiling module (subscriber initialization utilities) | `rust/lancedb/src/profiling.rs` (new file) |
+| Export profiling module in `lib.rs` | `rust/lancedb/src/lib.rs` |
+| Update Node.js bindings Cargo.toml | `nodejs/Cargo.toml` |
+
+### Phase 2: Critical Path Instrumentation (moderate risk, ~4 files)
+
+| Change | File |
+|--------|------|
+| Add `#[instrument]` to `Table` public methods | `rust/lancedb/src/table.rs` |
+| Add spans to `ExecutableQuery::execute_with_options` | `rust/lancedb/src/query.rs` |
+| Add tracing spans to `IoTrackingStore` methods | `rust/lancedb/src/io/object_store/io_tracking.rs` |
+| Add instrument to `NativeTable` / `RemoteTable` key methods | `rust/lancedb/src/table.rs`, `rust/lancedb/src/remote/table.rs` |
+
+### Phase 3: Node.js Bindings (low risk, ~3 files)
+
+| Change | File |
+|--------|------|
+| Expose profiling initialization function | `nodejs/src/lib.rs` |
+| TypeScript type definitions and wrappers | `nodejs/src/index.ts` (or new file) |
+| Update `env_logger` initialization for tracing compatibility | `nodejs/src/lib.rs` |
+
+### Expected Impact
+
+- **New dependencies** (feature-gated): `tracing` (0.1), `tracing-subscriber`,
+  `tracing-opentelemetry`, `opentelemetry` (0.28+), `opentelemetry_sdk`,
+  `opentelemetry-otlp`
+- **Code change volume**: ~200-300 lines added, ~50 lines modified
+- **API changes**: Only new `profiling` module public API added, no breaking changes
+- **Performance impact**: < 5ns/span when no subscriber is enabled; depends on sampling rate with OTLP export
+- **Compilation impact**: Zero impact when features are not enabled; enabling `profiling-otlp` feature adds ~10-15s compile time (from the OpenTelemetry crate tree)

--- a/docs/src/performance-profiling-design.md
+++ b/docs/src/performance-profiling-design.md
@@ -79,7 +79,7 @@ Key traits:
 
 - Instrumentation changes inside the Lance library (maintained by upstream)
 - Real-time dashboards or UI visualization
-- Custom metrics (e.g., histograms, counters) — first phase focuses on tracing only
+- Custom metrics beyond I/O tracking (e.g., query-level histograms) — first phase focuses on tracing and basic I/O metrics (read/write bytes, IOPS, duration)
 - CPU profiling (e.g., pprof integration)
 - Memory allocation tracking
 
@@ -208,7 +208,8 @@ use lancedb::profiling;
 profiling::init_json_subscriber();
 
 // Option 2: Use OTLP export
-profiling::init_otlp_subscriber("http://localhost:4317");
+let otlp_config = profiling::OtlpConfig::default();
+let _guard = profiling::init_otlp(otlp_config).unwrap();
 
 // Option 3: User-built subscriber (full control)
 use tracing_subscriber::prelude::*;
@@ -221,10 +222,10 @@ tracing_subscriber::registry()
 #### Node.js Users
 
 ```typescript
-import { initProfiling } from 'vectordb';
+import { initProfiling } from '@lancedb/lancedb';
 
 // Enable OTLP export
-initProfiling({ otlpEndpoint: 'http://localhost:4317' });
+initProfiling({ endpoint: 'http://localhost:4318' });
 
 // Or JSON log output
 initProfiling({ format: 'json' });

--- a/nodejs/Cargo.toml
+++ b/nodejs/Cargo.toml
@@ -18,7 +18,10 @@ arrow-array.workspace = true
 arrow-buffer = "57.2"
 half.workspace = true
 arrow-schema.workspace = true
-env_logger.workspace = true
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
 futures.workspace = true
 lancedb = { path = "../rust/lancedb", default-features = false }
 napi = { version = "3.8.3", default-features = false, features = [
@@ -28,7 +31,6 @@ napi = { version = "3.8.3", default-features = false, features = [
 napi-derive = "3.5.2"
 # Prevent dynamic linking of lzma, which comes from datafusion
 lzma-sys = { version = "0.1", features = ["static"] }
-log.workspace = true
 
 # Pin to resolve build failures; update periodically for security patches.
 aws-lc-sys = "=0.38.0"
@@ -38,5 +40,11 @@ aws-lc-rs = "=1.16.1"
 napi-build = "2.3.1"
 
 [features]
-default = ["lancedb/aws", "lancedb/gcs", "lancedb/azure", "lancedb/dynamodb", "lancedb/oss", "lancedb/huggingface"]
+# profiling-otlp is included in default because this fork always deploys with
+# profiling enabled. The zero-cost principle applies to the Rust core library
+# (`rust/lancedb`) where `default = []`; here in the Node.js bindings we opt
+# in unconditionally.
+default = ["profiling-otlp", "lancedb/aws", "lancedb/gcs", "lancedb/azure", "lancedb/dynamodb", "lancedb/oss", "lancedb/huggingface"]
 fp16kernels = ["lancedb/fp16kernels"]
+profiling = ["lancedb/profiling"]
+profiling-otlp = ["lancedb/profiling-otlp", "dep:tracing-opentelemetry", "dep:opentelemetry"]

--- a/nodejs/lancedb/index.ts
+++ b/nodejs/lancedb/index.ts
@@ -10,7 +10,9 @@ import {
 import {
   ConnectionOptions,
   Connection as LanceDbConnection,
+  ProfilingOptions,
   Session,
+  initProfiling as nativeInitProfiling,
 } from "./native.js";
 
 export {
@@ -74,6 +76,7 @@ export {
   FullTextQueryType,
   Operator,
   Occur,
+  withTraceparent,
 } from "./query";
 
 export {
@@ -111,6 +114,35 @@ export {
   MultiVector,
 } from "./arrow";
 export { IntoSql, packBits } from "./util";
+
+/**
+ * Initialize OTLP profiling for traces, metrics, and logs.
+ *
+ * Sets up the OpenTelemetry pipeline to export telemetry data to
+ * an OTLP-compatible collector (e.g. Grafana Alloy, OpenTelemetry Collector).
+ *
+ * Can be called at any time — the global subscriber installed at module
+ * load supports hot-reloading, so there is no "must call before any
+ * LanceDB operations" constraint.
+ *
+ * Requires the native library to be built with the `profiling-otlp` feature.
+ *
+ * @param options - Optional configuration for the OTLP endpoint.
+ *
+ * @example
+ * ```ts
+ * import { initProfiling } from "lancedb";
+ *
+ * initProfiling({
+ *   otlpEndpoint: "http://localhost:4318",
+ *   serviceName: "my-app",
+ * });
+ * ```
+ */
+export function initProfiling(options?: ProfilingOptions): void {
+  nativeInitProfiling(options ?? undefined);
+}
+export type { ProfilingOptions } from "./native.js";
 
 /**
  * Connect to a LanceDB instance at the given URI.

--- a/nodejs/lancedb/query.ts
+++ b/nodejs/lancedb/query.ts
@@ -20,6 +20,85 @@ import {
   VectorQuery as NativeVectorQuery,
 } from "./native";
 import { Reranker } from "./rerankers";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * AsyncLocalStorage used to propagate a W3C traceparent string through
+ * the call chain without requiring an active OpenTelemetry span.
+ *
+ * This is useful when the framework (e.g. Hono with @hono/node-server)
+ * does not propagate the OTel async context into route handlers.
+ *
+ * @hidden
+ */
+const traceparentStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Run a function with a specific W3C traceparent string.
+ *
+ * Any LanceDB operations called within `fn` will use this traceparent
+ * to link Rust-side tracing spans to the caller's trace.
+ *
+ * @example
+ * ```ts
+ * import { withTraceparent } from "@delta-ai/lancedb";
+ *
+ * // Inside a Hono / Express / Koa handler:
+ * const tp = req.headers.get("traceparent");
+ * const results = await withTraceparent(tp, () => table.query().limit(10).toArray());
+ * ```
+ */
+export function withTraceparent<T>(
+  traceparent: string | undefined,
+  fn: () => T,
+): T {
+  if (!traceparent) return fn();
+  return traceparentStorage.run(traceparent, fn);
+}
+
+/**
+ * Lazily cached reference to `@opentelemetry/api` module.
+ * Avoids calling `require()` on every `getTraceparent()` invocation.
+ * @hidden
+ */
+// biome-ignore lint/suspicious/noExplicitAny: dynamic optional dependency
+let otelApi: any | null | undefined; // undefined = not yet probed
+
+/**
+ * Extract the current W3C traceparent from the active OpenTelemetry span,
+ * if `@opentelemetry/api` is installed. Falls back to the value set via
+ * {@link withTraceparent}. Returns `undefined` when neither is available.
+ * @hidden
+ */
+export function getTraceparent(): string | undefined {
+  // 1. Check AsyncLocalStorage (set via withTraceparent)
+  const stored = traceparentStorage.getStore();
+  if (stored) {
+    return stored;
+  }
+
+  // 2. Try OTel active span (lazy-load the module once)
+  if (otelApi === undefined) {
+    try {
+      otelApi = require("@opentelemetry/api");
+    } catch {
+      otelApi = null; // @opentelemetry/api not installed
+    }
+  }
+  if (otelApi === null) return undefined;
+
+  try {
+    const span = otelApi.trace.getActiveSpan();
+    if (!span) return undefined;
+    const ctx = span.spanContext();
+    if (!ctx.traceId || ctx.traceId === "00000000000000000000000000000000")
+      return undefined;
+    const flags = (ctx.traceFlags ?? 1).toString(16).padStart(2, "0");
+    return `00-${ctx.traceId}-${ctx.spanId}-${flags}`;
+  } catch {
+    return undefined;
+  }
+}
 
 export async function* RecordBatchIterator(
   promisedInner: Promise<NativeBatchIterator>,
@@ -55,8 +134,13 @@ class RecordBatchIterable<
 
   // biome-ignore lint/suspicious/noExplicitAny: skip
   [Symbol.asyncIterator](): AsyncIterator<RecordBatch<any>, any, undefined> {
+    const traceparent = getTraceparent();
     return RecordBatchIterator(
-      this.inner.execute(this.options?.maxBatchLength, this.options?.timeoutMs),
+      this.inner.execute(
+        this.options?.maxBatchLength,
+        this.options?.timeoutMs,
+        traceparent,
+      ),
     );
   }
 }
@@ -202,12 +286,17 @@ export class QueryBase<
   protected nativeExecute(
     options?: Partial<QueryExecutionOptions>,
   ): Promise<NativeBatchIterator> {
+    const traceparent = getTraceparent();
     if (this.inner instanceof Promise) {
       return this.inner.then((inner) =>
-        inner.execute(options?.maxBatchLength, options?.timeoutMs),
+        inner.execute(options?.maxBatchLength, options?.timeoutMs, traceparent),
       );
     } else {
-      return this.inner.execute(options?.maxBatchLength, options?.timeoutMs);
+      return this.inner.execute(
+        options?.maxBatchLength,
+        options?.timeoutMs,
+        traceparent,
+      );
     }
   }
 

--- a/nodejs/lancedb/query.ts
+++ b/nodejs/lancedb/query.ts
@@ -91,8 +91,8 @@ export function getTraceparent(): string | undefined {
     const span = otelApi.trace.getActiveSpan();
     if (!span) return undefined;
     const ctx = span.spanContext();
-    if (!ctx.traceId || ctx.traceId === "00000000000000000000000000000000")
-      return undefined;
+    const INVALID_TRACE_ID = "00000000000000000000000000000000";
+    if (!ctx.traceId || ctx.traceId === INVALID_TRACE_ID) return undefined;
     const flags = (ctx.traceFlags ?? 1).toString(16).padStart(2, "0");
     return `00-${ctx.traceId}-${ctx.spanId}-${flags}`;
   } catch {

--- a/nodejs/lancedb/query.ts
+++ b/nodejs/lancedb/query.ts
@@ -58,25 +58,11 @@ export function withTraceparent<T>(
 
 /**
  * Lazily cached reference to `@opentelemetry/api` module.
- *
- * We kick off an async `import()` at module load time so the module is ready
- * by the time user code calls `getTraceparent()`.  The `import()` approach
- * is bundler-friendly (works with Webpack, Vite, Rollup, ESM and CJS) whereas
- * a bare `require()` would break under `"type": "module"` or ESM-only bundlers.
- *
- * If `@opentelemetry/api` is not installed the promise rejects and we set
- * `otelApi` to `null` so subsequent calls skip the probe entirely.
+ * Uses dynamic `import()` for ESM/bundler compatibility.
  * @hidden
  */
 // biome-ignore lint/suspicious/noExplicitAny: dynamic optional dependency
-let otelApi: any | null | undefined; // undefined = not yet resolved
-import("@opentelemetry/api")
-  .then((m) => {
-    otelApi = m;
-  })
-  .catch(() => {
-    otelApi = null;
-  });
+let otelApi: any | null | undefined; // undefined = not yet probed
 
 /**
  * Extract the current W3C traceparent from the active OpenTelemetry span,
@@ -84,15 +70,22 @@ import("@opentelemetry/api")
  * {@link withTraceparent}. Returns `undefined` when neither is available.
  * @hidden
  */
-export function getTraceparent(): string | undefined {
+export async function getTraceparent(): Promise<string | undefined> {
   // 1. Check AsyncLocalStorage (set via withTraceparent)
   const stored = traceparentStorage.getStore();
   if (stored) {
     return stored;
   }
 
-  // 2. Try OTel active span (probed asynchronously at module load)
-  if (otelApi === undefined || otelApi === null) return undefined;
+  // 2. Try OTel active span (lazy-load the module once via dynamic import)
+  if (otelApi === undefined) {
+    try {
+      otelApi = await import("@opentelemetry/api");
+    } catch {
+      otelApi = null; // @opentelemetry/api not installed
+    }
+  }
+  if (otelApi === null) return undefined;
 
   try {
     const span = otelApi.trace.getActiveSpan();
@@ -141,14 +134,14 @@ class RecordBatchIterable<
 
   // biome-ignore lint/suspicious/noExplicitAny: skip
   [Symbol.asyncIterator](): AsyncIterator<RecordBatch<any>, any, undefined> {
-    const traceparent = getTraceparent();
-    return RecordBatchIterator(
+    const innerPromise = getTraceparent().then((traceparent) =>
       this.inner.execute(
         this.options?.maxBatchLength,
         this.options?.timeoutMs,
         traceparent,
       ),
     );
+    return RecordBatchIterator(innerPromise);
   }
 }
 
@@ -290,13 +283,15 @@ export class QueryBase<
   /**
    * @hidden
    */
-  protected nativeExecute(
+  protected async nativeExecute(
     options?: Partial<QueryExecutionOptions>,
   ): Promise<NativeBatchIterator> {
-    const traceparent = getTraceparent();
+    const traceparent = await getTraceparent();
     if (this.inner instanceof Promise) {
-      return this.inner.then((inner) =>
-        inner.execute(options?.maxBatchLength, options?.timeoutMs, traceparent),
+      return (await this.inner).execute(
+        options?.maxBatchLength,
+        options?.timeoutMs,
+        traceparent,
       );
     } else {
       return this.inner.execute(

--- a/nodejs/lancedb/query.ts
+++ b/nodejs/lancedb/query.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
   Table as ArrowTable,
   type IntoVector,
@@ -20,7 +21,6 @@ import {
   VectorQuery as NativeVectorQuery,
 } from "./native";
 import { Reranker } from "./rerankers";
-import { AsyncLocalStorage } from "node:async_hooks";
 
 /**
  * AsyncLocalStorage used to propagate a W3C traceparent string through
@@ -91,8 +91,8 @@ export async function getTraceparent(): Promise<string | undefined> {
     const span = otelApi.trace.getActiveSpan();
     if (!span) return undefined;
     const ctx = span.spanContext();
-    const INVALID_TRACE_ID = "00000000000000000000000000000000";
-    if (!ctx.traceId || ctx.traceId === INVALID_TRACE_ID) return undefined;
+    const invalidTraceId = "00000000000000000000000000000000";
+    if (!ctx.traceId || ctx.traceId === invalidTraceId) return undefined;
     const flags = (ctx.traceFlags ?? 1).toString(16).padStart(2, "0");
     return `00-${ctx.traceId}-${ctx.spanId}-${flags}`;
   } catch {

--- a/nodejs/lancedb/query.ts
+++ b/nodejs/lancedb/query.ts
@@ -58,11 +58,25 @@ export function withTraceparent<T>(
 
 /**
  * Lazily cached reference to `@opentelemetry/api` module.
- * Avoids calling `require()` on every `getTraceparent()` invocation.
+ *
+ * We kick off an async `import()` at module load time so the module is ready
+ * by the time user code calls `getTraceparent()`.  The `import()` approach
+ * is bundler-friendly (works with Webpack, Vite, Rollup, ESM and CJS) whereas
+ * a bare `require()` would break under `"type": "module"` or ESM-only bundlers.
+ *
+ * If `@opentelemetry/api` is not installed the promise rejects and we set
+ * `otelApi` to `null` so subsequent calls skip the probe entirely.
  * @hidden
  */
 // biome-ignore lint/suspicious/noExplicitAny: dynamic optional dependency
-let otelApi: any | null | undefined; // undefined = not yet probed
+let otelApi: any | null | undefined; // undefined = not yet resolved
+import("@opentelemetry/api")
+  .then((m) => {
+    otelApi = m;
+  })
+  .catch(() => {
+    otelApi = null;
+  });
 
 /**
  * Extract the current W3C traceparent from the active OpenTelemetry span,
@@ -77,15 +91,8 @@ export function getTraceparent(): string | undefined {
     return stored;
   }
 
-  // 2. Try OTel active span (lazy-load the module once)
-  if (otelApi === undefined) {
-    try {
-      otelApi = require("@opentelemetry/api");
-    } catch {
-      otelApi = null; // @opentelemetry/api not installed
-    }
-  }
-  if (otelApi === null) return undefined;
+  // 2. Try OTel active span (probed asynchronously at module load)
+  if (otelApi === undefined || otelApi === null) return undefined;
 
   try {
     const span = otelApi.trace.getActiveSpan();

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -40,6 +40,7 @@ import {
   Query,
   TakeQuery,
   VectorQuery,
+  getTraceparent,
   instanceOfFullTextQuery,
 } from "./query";
 import { sanitizeType } from "./sanitize";
@@ -661,7 +662,7 @@ export class LocalTable extends Table {
     const schema = await this.schema();
 
     const buffer = await fromDataToBuffer(data, undefined, schema);
-    return await this.inner.add(buffer, mode);
+    return await this.inner.add(buffer, mode, getTraceparent());
   }
 
   async update(
@@ -721,15 +722,15 @@ export class LocalTable extends Table {
         columns = Object.entries(optsOrUpdates as Record<string, string>);
         predicate = options?.where;
     }
-    return await this.inner.update(predicate, columns);
+    return await this.inner.update(predicate, columns, getTraceparent());
   }
 
   async countRows(filter?: string): Promise<number> {
-    return await this.inner.countRows(filter);
+    return await this.inner.countRows(filter, getTraceparent());
   }
 
   async delete(predicate: string): Promise<DeleteResult> {
-    return await this.inner.delete(predicate);
+    return await this.inner.delete(predicate, getTraceparent());
   }
 
   async createIndex(column: string, options?: Partial<IndexOptions>) {
@@ -743,6 +744,7 @@ export class LocalTable extends Table {
       options?.waitTimeoutSeconds,
       options?.name,
       options?.train,
+      getTraceparent(),
     );
   }
 
@@ -989,6 +991,7 @@ export class LocalTable extends Table {
       cleanupOlderThanMs,
       options?.deleteUnverified,
       options?.errorIfTaggedOldVersions,
+      getTraceparent(),
     );
   }
 

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -662,7 +662,7 @@ export class LocalTable extends Table {
     const schema = await this.schema();
 
     const buffer = await fromDataToBuffer(data, undefined, schema);
-    return await this.inner.add(buffer, mode, getTraceparent());
+    return await this.inner.add(buffer, mode, await getTraceparent());
   }
 
   async update(
@@ -722,15 +722,15 @@ export class LocalTable extends Table {
         columns = Object.entries(optsOrUpdates as Record<string, string>);
         predicate = options?.where;
     }
-    return await this.inner.update(predicate, columns, getTraceparent());
+    return await this.inner.update(predicate, columns, await getTraceparent());
   }
 
   async countRows(filter?: string): Promise<number> {
-    return await this.inner.countRows(filter, getTraceparent());
+    return await this.inner.countRows(filter, await getTraceparent());
   }
 
   async delete(predicate: string): Promise<DeleteResult> {
-    return await this.inner.delete(predicate, getTraceparent());
+    return await this.inner.delete(predicate, await getTraceparent());
   }
 
   async createIndex(column: string, options?: Partial<IndexOptions>) {
@@ -744,7 +744,7 @@ export class LocalTable extends Table {
       options?.waitTimeoutSeconds,
       options?.name,
       options?.train,
-      getTraceparent(),
+      await getTraceparent(),
     );
   }
 
@@ -991,7 +991,7 @@ export class LocalTable extends Table {
       cleanupOlderThanMs,
       options?.deleteUnverified,
       options?.errorIfTaggedOldVersions,
-      getTraceparent(),
+      await getTraceparent(),
     );
   }
 

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -27,6 +27,9 @@
         "@biomejs/biome": "^1.7.3",
         "@jest/globals": "^29.7.0",
         "@napi-rs/cli": "^3.5.1",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/sdk-trace-node": "^2.6.1",
         "@types/axios": "^0.14.0",
         "@types/jest": "^29.1.2",
         "@types/node": "^22.7.4",
@@ -1182,6 +1185,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
       "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -4195,6 +4199,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4344,6 +4349,109 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
+      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.1.tgz",
+      "integrity": "sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.6.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5457,6 +5565,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5659,6 +5768,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5771,7 +5881,6 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-15.0.0.tgz",
       "integrity": "sha512-e6aunxNKM+woQf137ny3tp/xbLjFJS2oGQxQhYGqW6dGeIwNV1jOeEAeR6sS2jwAI2qLO83gYIP2MBz02Gw5Xw==",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.2",
         "@types/command-line-args": "^5.2.1",
@@ -5959,7 +6068,6 @@
       "version": "20.16.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.10.tgz",
       "integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -5967,8 +6075,7 @@
     "node_modules/apache-arrow/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "peer": true
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -6199,6 +6306,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001565",
         "electron-to-chromium": "^1.4.601",
@@ -6832,6 +6940,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7885,6 +7994,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10207,6 +10317,7 @@
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -44,6 +44,9 @@
     "@biomejs/biome": "^1.7.3",
     "@jest/globals": "^29.7.0",
     "@napi-rs/cli": "^3.5.1",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/sdk-trace-base": "^2.6.1",
+    "@opentelemetry/sdk-trace-node": "^2.6.1",
     "@types/axios": "^0.14.0",
     "@types/jest": "^29.1.2",
     "@types/node": "^22.7.4",
@@ -68,8 +71,15 @@
   "engines": {
     "node": ">= 18"
   },
-  "cpu": ["x64", "arm64"],
-  "os": ["darwin", "linux", "win32"],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
   "scripts": {
     "artifacts": "napi artifacts",
     "build:debug": "napi build --platform --dts ../lancedb/native.d.ts --js ../lancedb/native.js --output-dir lancedb",
@@ -100,6 +110,12 @@
     "openai": "^4.29.2"
   },
   "peerDependencies": {
-    "apache-arrow": ">=15.0.0 <=18.1.0"
+    "apache-arrow": ">=15.0.0 <=18.1.0",
+    "@opentelemetry/api": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -71,15 +71,8 @@
   "engines": {
     "node": ">= 18"
   },
-  "cpu": [
-    "x64",
-    "arm64"
-  ],
-  "os": [
-    "darwin",
-    "linux",
-    "win32"
-  ],
+  "cpu": ["x64", "arm64"],
+  "os": ["darwin", "linux", "win32"],
   "scripts": {
     "artifacts": "napi artifacts",
     "build:debug": "napi build --platform --dts ../lancedb/native.d.ts --js ../lancedb/native.js --output-dir lancedb",

--- a/nodejs/scripts/test-traceparent.js
+++ b/nodejs/scripts/test-traceparent.js
@@ -12,36 +12,39 @@
  * Run:  node scripts/test-traceparent.js
  */
 
-const { context, trace, SpanStatusCode } = require('@opentelemetry/api');
-const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
-const { InMemorySpanExporter, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
-const lancedb = require('../dist/index.js');
-const { getTraceparent } = require('../dist/query.js');
-const fs = require('node:fs');
-const path = require('node:path');
-const os = require('node:os');
+const { context, trace, SpanStatusCode } = require("@opentelemetry/api");
+const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
+const {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} = require("@opentelemetry/sdk-trace-base");
+const lancedb = require("../dist/index.js");
+const { getTraceparent } = require("../dist/query.js");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
 
 // ─── Setup OTel with InMemory exporter ───────────────────────────────────────
 
 const exporter = new InMemorySpanExporter();
 const provider = new NodeTracerProvider({
-    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
 });
 provider.register();
-const tracer = trace.getTracer('test-traceparent');
+const tracer = trace.getTracer("test-traceparent");
 
 // ─── Setup temp LanceDB directory ────────────────────────────────────────────
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lance-trace-test-'));
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lance-trace-test-"));
 console.log(`[setup] Temp DB dir: ${tmpDir}`);
 
 // ─── Initialize LanceDB Rust profiling ───────────────────────────────────────
 
 try {
-    lancedb.initProfiling({ serviceName: 'lance-trace-test' });
-    console.log('[setup] LanceDB Rust profiling initialized');
+  lancedb.initProfiling({ serviceName: "lance-trace-test" });
+  console.log("[setup] LanceDB Rust profiling initialized");
 } catch (e) {
-    console.log(`[setup] LanceDB profiling init: ${e.message}`);
+  console.log(`[setup] LanceDB profiling init: ${e.message}`);
 }
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
@@ -50,132 +53,160 @@ let passed = 0;
 let failed = 0;
 
 function assert(condition, message) {
-    if (condition) {
-        console.log(`  ✅ ${message}`);
-        passed++;
-    } else {
-        console.error(`  ❌ FAIL: ${message}`);
-        failed++;
-    }
+  if (condition) {
+    console.log(`  ✅ ${message}`);
+    passed++;
+  } else {
+    console.error(`  ❌ FAIL: ${message}`);
+    failed++;
+  }
 }
 
 async function run() {
-    // ─── Test 1: getTraceparent() returns correct value inside an active span ─
+  // ─── Test 1: getTraceparent() returns correct value inside an active span ─
 
-    console.log('\n[Test 1] getTraceparent() inside an active span');
+  console.log("\n[Test 1] getTraceparent() inside an active span");
 
-    const parentSpan = tracer.startSpan('test.parent');
-    const parentCtx = trace.setSpan(context.active(), parentSpan);
+  const parentSpan = tracer.startSpan("test.parent");
+  const parentCtx = trace.setSpan(context.active(), parentSpan);
 
-    context.with(parentCtx, () => {
-        const tp = getTraceparent();
-        assert(tp !== undefined, 'getTraceparent() returns non-undefined');
+  context.with(parentCtx, () => {
+    const tp = getTraceparent();
+    assert(tp !== undefined, "getTraceparent() returns non-undefined");
 
-        if (tp) {
-            const parts = tp.split('-');
-            assert(parts.length === 4, `traceparent has 4 parts: ${tp}`);
-            assert(parts[0] === '00', `version is "00": ${parts[0]}`);
-            assert(parts[1].length === 32, `traceId is 32 hex chars: ${parts[1]}`);
-            assert(parts[2].length === 16, `spanId is 16 hex chars: ${parts[2]}`);
+    if (tp) {
+      const parts = tp.split("-");
+      assert(parts.length === 4, `traceparent has 4 parts: ${tp}`);
+      assert(parts[0] === "00", `version is "00": ${parts[0]}`);
+      assert(parts[1].length === 32, `traceId is 32 hex chars: ${parts[1]}`);
+      assert(parts[2].length === 16, `spanId is 16 hex chars: ${parts[2]}`);
 
-            const spanCtx = parentSpan.spanContext();
-            assert(parts[1] === spanCtx.traceId, `traceId matches: ${parts[1]} === ${spanCtx.traceId}`);
-            assert(parts[2] === spanCtx.spanId, `spanId matches: ${parts[2]} === ${spanCtx.spanId}`);
-        }
+      const spanCtx = parentSpan.spanContext();
+      assert(
+        parts[1] === spanCtx.traceId,
+        `traceId matches: ${parts[1]} === ${spanCtx.traceId}`,
+      );
+      assert(
+        parts[2] === spanCtx.spanId,
+        `spanId matches: ${parts[2]} === ${spanCtx.spanId}`,
+      );
+    }
+  });
+
+  parentSpan.end();
+
+  // ─── Test 2: getTraceparent() returns undefined when no active span ──────
+
+  console.log("\n[Test 2] getTraceparent() without an active span");
+
+  const tpNoSpan = getTraceparent();
+  assert(
+    tpNoSpan === undefined,
+    "getTraceparent() returns undefined when no active span",
+  );
+
+  // ─── Test 3: LanceDB query with traceparent (full E2E) ──────────────────
+
+  console.log("\n[Test 3] LanceDB query with traceparent injection");
+
+  const querySpan = tracer.startSpan("test.lancedb.query");
+  const queryCtx = trace.setSpan(context.active(), querySpan);
+
+  try {
+    await context.with(queryCtx, async () => {
+      const tp = getTraceparent();
+      assert(tp !== undefined, "traceparent available for query");
+      console.log(`  traceparent: ${tp}`);
+
+      // Create a test connection and table
+      const conn = await lancedb.connect(tmpDir);
+      const table = await conn.createTable("test_trace", [
+        {
+          id: "1",
+          text: "hello",
+          vector: Array.from({ length: 8 }, () => Math.random()),
+        },
+        {
+          id: "2",
+          text: "world",
+          vector: Array.from({ length: 8 }, () => Math.random()),
+        },
+      ]);
+
+      // Execute a query — this will pass traceparent to Rust via NAPI
+      const results = await table.query().limit(10).toArray();
+      assert(
+        results.length === 2,
+        `query returned ${results.length} results (expected 2)`,
+      );
+
+      // Execute a countRows — also passes traceparent
+      const count = await table.countRows();
+      assert(count === 2, `countRows returned ${count} (expected 2)`);
+
+      // Vector search
+      const vecResults = await table
+        .search(Array.from({ length: 8 }, () => Math.random()))
+        .limit(1)
+        .toArray();
+      assert(
+        vecResults.length === 1,
+        `vector search returned ${vecResults.length} results (expected 1)`,
+      );
+
+      querySpan.setStatus({ code: SpanStatusCode.OK });
     });
+  } catch (error) {
+    querySpan.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
+    console.error("  ❌ Query test failed:", error);
+    failed++;
+  } finally {
+    querySpan.end();
+  }
 
-    parentSpan.end();
+  // ─── Test 4: Verify exported spans ──────────────────────────────────────
 
-    // ─── Test 2: getTraceparent() returns undefined when no active span ──────
+  console.log("\n[Test 4] Verify exported OTel spans");
 
-    console.log('\n[Test 2] getTraceparent() without an active span');
+  await provider.forceFlush();
+  const spans = exporter.getFinishedSpans();
+  assert(spans.length >= 2, `${spans.length} spans exported (expected >= 2)`);
 
-    const tpNoSpan = getTraceparent();
-    assert(tpNoSpan === undefined, 'getTraceparent() returns undefined when no active span');
+  const spanNames = spans.map((s) => s.name);
+  console.log(`  Exported spans: ${JSON.stringify(spanNames)}`);
+  assert(spanNames.includes("test.parent"), "test.parent span exported");
+  assert(
+    spanNames.includes("test.lancedb.query"),
+    "test.lancedb.query span exported",
+  );
 
-    // ─── Test 3: LanceDB query with traceparent (full E2E) ──────────────────
+  // Verify the query span has a valid traceId
+  const queryExportedSpan = spans.find((s) => s.name === "test.lancedb.query");
+  if (queryExportedSpan) {
+    const traceId = queryExportedSpan.spanContext().traceId;
+    assert(traceId.length === 32, `query span has valid traceId: ${traceId}`);
+    console.log(`  Query span traceId: ${traceId}`);
+  }
 
-    console.log('\n[Test 3] LanceDB query with traceparent injection');
+  // ─── Cleanup ────────────────────────────────────────────────────────────
 
-    const querySpan = tracer.startSpan('test.lancedb.query');
-    const queryCtx = trace.setSpan(context.active(), querySpan);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  await provider.shutdown();
 
-    try {
-        await context.with(queryCtx, async () => {
-            const tp = getTraceparent();
-            assert(tp !== undefined, 'traceparent available for query');
-            console.log(`  traceparent: ${tp}`);
+  // ─── Summary ────────────────────────────────────────────────────────────
 
-            // Create a test connection and table
-            const conn = await lancedb.connect(tmpDir);
-            const table = await conn.createTable('test_trace', [
-                { id: '1', text: 'hello', vector: Array.from({ length: 8 }, () => Math.random()) },
-                { id: '2', text: 'world', vector: Array.from({ length: 8 }, () => Math.random()) },
-            ]);
-
-            // Execute a query — this will pass traceparent to Rust via NAPI
-            const results = await table.query().limit(10).toArray();
-            assert(results.length === 2, `query returned ${results.length} results (expected 2)`);
-
-            // Execute a countRows — also passes traceparent
-            const count = await table.countRows();
-            assert(count === 2, `countRows returned ${count} (expected 2)`);
-
-            // Vector search
-            const vecResults = await table
-                .search(Array.from({ length: 8 }, () => Math.random()))
-                .limit(1)
-                .toArray();
-            assert(vecResults.length === 1, `vector search returned ${vecResults.length} results (expected 1)`);
-
-            querySpan.setStatus({ code: SpanStatusCode.OK });
-        });
-    } catch (error) {
-        querySpan.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
-        console.error('  ❌ Query test failed:', error);
-        failed++;
-    } finally {
-        querySpan.end();
-    }
-
-    // ─── Test 4: Verify exported spans ──────────────────────────────────────
-
-    console.log('\n[Test 4] Verify exported OTel spans');
-
-    await provider.forceFlush();
-    const spans = exporter.getFinishedSpans();
-    assert(spans.length >= 2, `${spans.length} spans exported (expected >= 2)`);
-
-    const spanNames = spans.map(s => s.name);
-    console.log(`  Exported spans: ${JSON.stringify(spanNames)}`);
-    assert(spanNames.includes('test.parent'), 'test.parent span exported');
-    assert(spanNames.includes('test.lancedb.query'), 'test.lancedb.query span exported');
-
-    // Verify the query span has a valid traceId
-    const queryExportedSpan = spans.find(s => s.name === 'test.lancedb.query');
-    if (queryExportedSpan) {
-        const traceId = queryExportedSpan.spanContext().traceId;
-        assert(traceId.length === 32, `query span has valid traceId: ${traceId}`);
-        console.log(`  Query span traceId: ${traceId}`);
-    }
-
-    // ─── Cleanup ────────────────────────────────────────────────────────────
-
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-    await provider.shutdown();
-
-    // ─── Summary ────────────────────────────────────────────────────────────
-
-    console.log(`\n${'─'.repeat(60)}`);
-    console.log(`Results: ${passed} passed, ${failed} failed`);
-    if (failed > 0) {
-        process.exit(1);
-    } else {
-        console.log('All tests passed! Traceparent propagation is working correctly.');
-    }
+  console.log(`\n${"─".repeat(60)}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  if (failed > 0) {
+    process.exit(1);
+  } else {
+    console.log(
+      "All tests passed! Traceparent propagation is working correctly.",
+    );
+  }
 }
 
 run().catch((err) => {
-    console.error('Fatal error:', err);
-    process.exit(1);
+  console.error("Fatal error:", err);
+  process.exit(1);
 });

--- a/nodejs/scripts/test-traceparent.js
+++ b/nodejs/scripts/test-traceparent.js
@@ -9,7 +9,7 @@
  * 4. Verifies getTraceparent() returns the correct traceparent string
  * 5. Verifies LanceDB operations succeed with the traceparent injected
  *
- * Run:  node --import tsx scripts/test-traceparent.ts
+ * Run:  node scripts/test-traceparent.js
  */
 
 const { context, trace, SpanStatusCode } = require('@opentelemetry/api');

--- a/nodejs/scripts/test-traceparent.js
+++ b/nodejs/scripts/test-traceparent.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Integration test: verify traceparent propagation from OTel JS → LanceDB Rust NAPI.
+ *
+ * This script:
+ * 1. Initializes an OTel SDK with an InMemory span exporter
+ * 2. Creates a parent span simulating an API handler
+ * 3. Within that span context, calls LanceDB query operations
+ * 4. Verifies getTraceparent() returns the correct traceparent string
+ * 5. Verifies LanceDB operations succeed with the traceparent injected
+ *
+ * Run:  node --import tsx scripts/test-traceparent.ts
+ */
+
+const { context, trace, SpanStatusCode } = require('@opentelemetry/api');
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const { InMemorySpanExporter, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
+const lancedb = require('../dist/index.js');
+const { getTraceparent } = require('../dist/query.js');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+// ─── Setup OTel with InMemory exporter ───────────────────────────────────────
+
+const exporter = new InMemorySpanExporter();
+const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+provider.register();
+const tracer = trace.getTracer('test-traceparent');
+
+// ─── Setup temp LanceDB directory ────────────────────────────────────────────
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lance-trace-test-'));
+console.log(`[setup] Temp DB dir: ${tmpDir}`);
+
+// ─── Initialize LanceDB Rust profiling ───────────────────────────────────────
+
+try {
+    lancedb.initProfiling({ serviceName: 'lance-trace-test' });
+    console.log('[setup] LanceDB Rust profiling initialized');
+} catch (e) {
+    console.log(`[setup] LanceDB profiling init: ${e.message}`);
+}
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+    if (condition) {
+        console.log(`  ✅ ${message}`);
+        passed++;
+    } else {
+        console.error(`  ❌ FAIL: ${message}`);
+        failed++;
+    }
+}
+
+async function run() {
+    // ─── Test 1: getTraceparent() returns correct value inside an active span ─
+
+    console.log('\n[Test 1] getTraceparent() inside an active span');
+
+    const parentSpan = tracer.startSpan('test.parent');
+    const parentCtx = trace.setSpan(context.active(), parentSpan);
+
+    context.with(parentCtx, () => {
+        const tp = getTraceparent();
+        assert(tp !== undefined, 'getTraceparent() returns non-undefined');
+
+        if (tp) {
+            const parts = tp.split('-');
+            assert(parts.length === 4, `traceparent has 4 parts: ${tp}`);
+            assert(parts[0] === '00', `version is "00": ${parts[0]}`);
+            assert(parts[1].length === 32, `traceId is 32 hex chars: ${parts[1]}`);
+            assert(parts[2].length === 16, `spanId is 16 hex chars: ${parts[2]}`);
+
+            const spanCtx = parentSpan.spanContext();
+            assert(parts[1] === spanCtx.traceId, `traceId matches: ${parts[1]} === ${spanCtx.traceId}`);
+            assert(parts[2] === spanCtx.spanId, `spanId matches: ${parts[2]} === ${spanCtx.spanId}`);
+        }
+    });
+
+    parentSpan.end();
+
+    // ─── Test 2: getTraceparent() returns undefined when no active span ──────
+
+    console.log('\n[Test 2] getTraceparent() without an active span');
+
+    const tpNoSpan = getTraceparent();
+    assert(tpNoSpan === undefined, 'getTraceparent() returns undefined when no active span');
+
+    // ─── Test 3: LanceDB query with traceparent (full E2E) ──────────────────
+
+    console.log('\n[Test 3] LanceDB query with traceparent injection');
+
+    const querySpan = tracer.startSpan('test.lancedb.query');
+    const queryCtx = trace.setSpan(context.active(), querySpan);
+
+    try {
+        await context.with(queryCtx, async () => {
+            const tp = getTraceparent();
+            assert(tp !== undefined, 'traceparent available for query');
+            console.log(`  traceparent: ${tp}`);
+
+            // Create a test connection and table
+            const conn = await lancedb.connect(tmpDir);
+            const table = await conn.createTable('test_trace', [
+                { id: '1', text: 'hello', vector: Array.from({ length: 8 }, () => Math.random()) },
+                { id: '2', text: 'world', vector: Array.from({ length: 8 }, () => Math.random()) },
+            ]);
+
+            // Execute a query — this will pass traceparent to Rust via NAPI
+            const results = await table.query().limit(10).toArray();
+            assert(results.length === 2, `query returned ${results.length} results (expected 2)`);
+
+            // Execute a countRows — also passes traceparent
+            const count = await table.countRows();
+            assert(count === 2, `countRows returned ${count} (expected 2)`);
+
+            // Vector search
+            const vecResults = await table
+                .search(Array.from({ length: 8 }, () => Math.random()))
+                .limit(1)
+                .toArray();
+            assert(vecResults.length === 1, `vector search returned ${vecResults.length} results (expected 1)`);
+
+            querySpan.setStatus({ code: SpanStatusCode.OK });
+        });
+    } catch (error) {
+        querySpan.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
+        console.error('  ❌ Query test failed:', error);
+        failed++;
+    } finally {
+        querySpan.end();
+    }
+
+    // ─── Test 4: Verify exported spans ──────────────────────────────────────
+
+    console.log('\n[Test 4] Verify exported OTel spans');
+
+    await provider.forceFlush();
+    const spans = exporter.getFinishedSpans();
+    assert(spans.length >= 2, `${spans.length} spans exported (expected >= 2)`);
+
+    const spanNames = spans.map(s => s.name);
+    console.log(`  Exported spans: ${JSON.stringify(spanNames)}`);
+    assert(spanNames.includes('test.parent'), 'test.parent span exported');
+    assert(spanNames.includes('test.lancedb.query'), 'test.lancedb.query span exported');
+
+    // Verify the query span has a valid traceId
+    const queryExportedSpan = spans.find(s => s.name === 'test.lancedb.query');
+    if (queryExportedSpan) {
+        const traceId = queryExportedSpan.spanContext().traceId;
+        assert(traceId.length === 32, `query span has valid traceId: ${traceId}`);
+        console.log(`  Query span traceId: ${traceId}`);
+    }
+
+    // ─── Cleanup ────────────────────────────────────────────────────────────
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    await provider.shutdown();
+
+    // ─── Summary ────────────────────────────────────────────────────────────
+
+    console.log(`\n${'─'.repeat(60)}`);
+    console.log(`Results: ${passed} passed, ${failed} failed`);
+    if (failed > 0) {
+        process.exit(1);
+    } else {
+        console.log('All tests passed! Traceparent propagation is working correctly.');
+    }
+}
+
+run().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+});

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
-use env_logger::Env;
 use napi_derive::*;
 
 mod connection;
@@ -16,7 +16,13 @@ mod query;
 mod rerankers;
 mod session;
 mod table;
+mod tracing_util;
 mod util;
+
+/// Stores the reload handle from init_subscriber() so that initProfiling()
+/// can hot-swap the tracing layers later.
+#[cfg(any(feature = "profiling", feature = "profiling-otlp"))]
+static RELOAD_HANDLE: OnceLock<lancedb::profiling::ReloadHandle> = OnceLock::new();
 
 #[napi(object)]
 #[derive(Debug)]
@@ -47,8 +53,86 @@ pub struct OpenTableOptions {
 
 #[napi_derive::module_init]
 fn init() {
-    let env = Env::new()
-        .filter_or("LANCEDB_LOG", "warn")
-        .write_style("LANCEDB_LOG_STYLE");
-    env_logger::init_from_env(env);
+    #[cfg(any(feature = "profiling", feature = "profiling-otlp"))]
+    {
+        let handle = lancedb::profiling::init_subscriber();
+        let _ = RELOAD_HANDLE.set(handle);
+    }
+
+    #[cfg(not(any(feature = "profiling", feature = "profiling-otlp")))]
+    {
+        use tracing_subscriber::EnvFilter;
+        let filter =
+            EnvFilter::try_from_env("LANCEDB_LOG").unwrap_or_else(|_| EnvFilter::new("warn"));
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .try_init()
+            .ok();
+    }
+}
+
+/// Options for configuring OTLP profiling export.
+#[napi(object)]
+pub struct ProfilingOptions {
+    /// The OTLP collector endpoint (e.g. "http://localhost:4318").
+    /// Falls back to OTEL_EXPORTER_OTLP_ENDPOINT env var.
+    pub otlp_endpoint: Option<String>,
+    /// The service name for telemetry (defaults to "lancedb").
+    /// Falls back to OTEL_SERVICE_NAME env var.
+    pub service_name: Option<String>,
+    /// Transport protocol: "http" (default) or "grpc".
+    pub protocol: Option<String>,
+}
+
+/// Initialize OTLP profiling for traces, metrics, and logs.
+///
+/// This hot-swaps the tracing subscriber's inner layers to export telemetry
+/// data to an OTLP-compatible collector (e.g. Grafana Alloy, OpenTelemetry
+/// Collector).
+///
+/// Can be called at any time — the global subscriber installed at module
+/// load supports hot-reloading, so no "must call before any LanceDB
+/// operations" constraint.
+///
+/// Requires the `profiling-otlp` feature to be enabled at build time.
+#[napi]
+pub fn init_profiling(options: Option<ProfilingOptions>) -> napi::Result<()> {
+    #[cfg(feature = "profiling-otlp")]
+    {
+        let handle = RELOAD_HANDLE
+            .get()
+            .ok_or_else(|| napi::Error::from_reason("Tracing subscriber not initialized"))?;
+
+        let mut config = lancedb::profiling::OtlpConfig::default();
+        if let Some(opts) = options {
+            if let Some(endpoint) = opts.otlp_endpoint {
+                config.endpoint = endpoint;
+            }
+            if let Some(name) = opts.service_name {
+                config.service_name = name;
+            }
+            if let Some(proto) = opts.protocol {
+                config.protocol = match proto.as_str() {
+                    "grpc" => lancedb::profiling::OtlpProtocol::Grpc,
+                    _ => lancedb::profiling::OtlpProtocol::Http,
+                };
+            }
+        }
+
+        // Store the guard in a static to prevent shutdown on drop
+        static GUARD: OnceLock<lancedb::profiling::OtlpGuard> = OnceLock::new();
+        let guard = lancedb::profiling::upgrade_to_otlp(handle, config)
+            .map_err(|e| napi::Error::from_reason(format!("Failed to init OTLP profiling: {e}")))?;
+        let _ = GUARD.set(guard);
+        Ok(())
+    }
+
+    #[cfg(not(feature = "profiling-otlp"))]
+    {
+        let _ = options;
+        Err(napi::Error::from_reason(
+            "OTLP profiling is not enabled. Rebuild with the 'profiling-otlp' feature flag."
+                .to_string(),
+        ))
+    }
 }

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -119,8 +119,12 @@ pub fn init_profiling(options: Option<ProfilingOptions>) -> napi::Result<()> {
             }
         }
 
-        // Store the guard in a static to prevent shutdown on drop
+        // Store the guard in a static to prevent shutdown on drop.
+        // If already initialized, return early (idempotent).
         static GUARD: OnceLock<lancedb::profiling::OtlpGuard> = OnceLock::new();
+        if GUARD.get().is_some() {
+            return Ok(());
+        }
         let guard = lancedb::profiling::upgrade_to_otlp(handle, config)
             .map_err(|e| napi::Error::from_reason(format!("Failed to init OTLP profiling: {e}")))?;
         let _ = GUARD.set(guard);

--- a/nodejs/src/query.rs
+++ b/nodejs/src/query.rs
@@ -22,6 +22,7 @@ use lancedb::query::TakeQuery as LanceDbTakeQuery;
 use lancedb::query::VectorQuery as LanceDbVectorQuery;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use tracing::Instrument;
 
 use crate::error::NapiErrorExt;
 use crate::error::convert_error;
@@ -139,7 +140,10 @@ impl Query {
         &self,
         max_batch_length: Option<u32>,
         timeout_ms: Option<u32>,
+        traceparent: Option<String>,
     ) -> napi::Result<RecordBatchIterator> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.query.execute");
+
         let mut execution_opts = QueryExecutionOptions::default();
         if let Some(max_batch_length) = max_batch_length {
             execution_opts.max_batch_length = max_batch_length;
@@ -150,6 +154,7 @@ impl Query {
         let inner_stream = self
             .inner
             .execute_with_options(execution_opts)
+            .instrument(span)
             .await
             .map_err(|e| {
                 napi::Error::from_reason(format!(
@@ -339,7 +344,11 @@ impl VectorQuery {
         &self,
         max_batch_length: Option<u32>,
         timeout_ms: Option<u32>,
+        traceparent: Option<String>,
     ) -> napi::Result<RecordBatchIterator> {
+        let span =
+            crate::tracing_util::napi_span!(traceparent, "lancedb.napi.vector_query.execute");
+
         let mut execution_opts = QueryExecutionOptions::default();
         if let Some(max_batch_length) = max_batch_length {
             execution_opts.max_batch_length = max_batch_length;
@@ -350,6 +359,7 @@ impl VectorQuery {
         let inner_stream = self
             .inner
             .execute_with_options(execution_opts)
+            .instrument(span)
             .await
             .map_err(|e| {
                 napi::Error::from_reason(format!(
@@ -418,7 +428,10 @@ impl TakeQuery {
         &self,
         max_batch_length: Option<u32>,
         timeout_ms: Option<u32>,
+        traceparent: Option<String>,
     ) -> napi::Result<RecordBatchIterator> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.take_query.execute");
+
         let mut execution_opts = QueryExecutionOptions::default();
         if let Some(max_batch_length) = max_batch_length {
             execution_opts.max_batch_length = max_batch_length;
@@ -429,6 +442,7 @@ impl TakeQuery {
         let inner_stream = self
             .inner
             .execute_with_options(execution_opts)
+            .instrument(span)
             .await
             .map_err(|e| {
                 napi::Error::from_reason(format!(

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -10,6 +10,7 @@ use lancedb::table::{
 };
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use tracing::Instrument;
 
 use crate::error::NapiErrorExt;
 use crate::index::Index;
@@ -68,7 +69,14 @@ impl Table {
     }
 
     #[napi(catch_unwind)]
-    pub async fn add(&self, buf: Buffer, mode: String) -> napi::Result<AddResult> {
+    pub async fn add(
+        &self,
+        buf: Buffer,
+        mode: String,
+        traceparent: Option<String>,
+    ) -> napi::Result<AddResult> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.table.add");
+
         let batches = ipc_file_to_batches(buf.to_vec())
             .map_err(|e| napi::Error::from_reason(format!("Failed to read IPC file: {}", e)))?;
         let batches = batches
@@ -92,26 +100,45 @@ impl Table {
             return Err(napi::Error::from_reason(format!("Invalid mode: {}", mode)));
         };
 
-        let res = op.execute().await.default_error()?;
+        let res = op.execute().instrument(span).await.default_error()?;
         Ok(res.into())
     }
 
     #[napi(catch_unwind)]
-    pub async fn count_rows(&self, filter: Option<String>) -> napi::Result<i64> {
+    pub async fn count_rows(
+        &self,
+        filter: Option<String>,
+        traceparent: Option<String>,
+    ) -> napi::Result<i64> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.table.count_rows");
+
         self.inner_ref()?
             .count_rows(filter)
+            .instrument(span)
             .await
             .map(|val| val as i64)
             .default_error()
     }
 
     #[napi(catch_unwind)]
-    pub async fn delete(&self, predicate: String) -> napi::Result<DeleteResult> {
-        let res = self.inner_ref()?.delete(&predicate).await.default_error()?;
+    pub async fn delete(
+        &self,
+        predicate: String,
+        traceparent: Option<String>,
+    ) -> napi::Result<DeleteResult> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.table.delete");
+
+        let res = self
+            .inner_ref()?
+            .delete(&predicate)
+            .instrument(span)
+            .await
+            .default_error()?;
         Ok(res.into())
     }
 
     #[napi(catch_unwind)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_index(
         &self,
         index: Option<&Index>,
@@ -120,7 +147,10 @@ impl Table {
         wait_timeout_s: Option<i64>,
         name: Option<String>,
         train: Option<bool>,
+        traceparent: Option<String>,
     ) -> napi::Result<()> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.table.create_index");
+
         let lancedb_index = if let Some(index) = index {
             index.consume()?
         } else {
@@ -140,7 +170,7 @@ impl Table {
         if let Some(train) = train {
             builder = builder.train(train);
         }
-        builder.execute().await.default_error()
+        builder.execute().instrument(span).await.default_error()
     }
 
     #[napi(catch_unwind)]
@@ -195,7 +225,10 @@ impl Table {
         &self,
         only_if: Option<String>,
         columns: Vec<(String, String)>,
+        traceparent: Option<String>,
     ) -> napi::Result<UpdateResult> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.table.update");
+
         let mut op = self.inner_ref()?.update();
         if let Some(only_if) = only_if {
             op = op.only_if(only_if);
@@ -203,7 +236,7 @@ impl Table {
         for (column_name, value) in columns {
             op = op.column(column_name, value);
         }
-        let res = op.execute().await.default_error()?;
+        let res = op.execute().instrument(span).await.default_error()?;
         Ok(res.into())
     }
 
@@ -444,7 +477,10 @@ impl Table {
         older_than_ms: Option<i64>,
         delete_unverified: Option<bool>,
         error_if_tagged_old_versions: Option<bool>,
+        traceparent: Option<String>,
     ) -> napi::Result<OptimizeStats> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.table.optimize");
+
         let inner = self.inner_ref()?;
 
         let older_than = if let Some(ms) = older_than_ms {
@@ -459,43 +495,47 @@ impl Table {
             None
         };
 
-        let compaction_stats = inner
-            .optimize(OptimizeAction::Compact {
-                options: lancedb::table::CompactionOptions::default(),
-                remap_options: None,
+        async {
+            let compaction_stats = inner
+                .optimize(OptimizeAction::Compact {
+                    options: lancedb::table::CompactionOptions::default(),
+                    remap_options: None,
+                })
+                .await
+                .default_error()?
+                .compaction
+                .unwrap();
+            let prune_stats = inner
+                .optimize(OptimizeAction::Prune {
+                    older_than,
+                    delete_unverified,
+                    error_if_tagged_old_versions,
+                })
+                .await
+                .default_error()?
+                .prune
+                .unwrap();
+            inner
+                .optimize(lancedb::table::OptimizeAction::Index(
+                    OptimizeOptions::default(),
+                ))
+                .await
+                .default_error()?;
+            Ok(OptimizeStats {
+                compaction: CompactionStats {
+                    files_added: compaction_stats.files_added as i64,
+                    files_removed: compaction_stats.files_removed as i64,
+                    fragments_added: compaction_stats.fragments_added as i64,
+                    fragments_removed: compaction_stats.fragments_removed as i64,
+                },
+                prune: RemovalStats {
+                    bytes_removed: prune_stats.bytes_removed as i64,
+                    old_versions_removed: prune_stats.old_versions as i64,
+                },
             })
-            .await
-            .default_error()?
-            .compaction
-            .unwrap();
-        let prune_stats = inner
-            .optimize(OptimizeAction::Prune {
-                older_than,
-                delete_unverified,
-                error_if_tagged_old_versions,
-            })
-            .await
-            .default_error()?
-            .prune
-            .unwrap();
-        inner
-            .optimize(lancedb::table::OptimizeAction::Index(
-                OptimizeOptions::default(),
-            ))
-            .await
-            .default_error()?;
-        Ok(OptimizeStats {
-            compaction: CompactionStats {
-                files_added: compaction_stats.files_added as i64,
-                files_removed: compaction_stats.files_removed as i64,
-                fragments_added: compaction_stats.fragments_added as i64,
-                fragments_removed: compaction_stats.fragments_removed as i64,
-            },
-            prune: RemovalStats {
-                bytes_removed: prune_stats.bytes_removed as i64,
-                old_versions_removed: prune_stats.old_versions as i64,
-            },
-        })
+        }
+        .instrument(span)
+        .await
     }
 
     #[napi(catch_unwind)]

--- a/nodejs/src/tracing_util.rs
+++ b/nodejs/src/tracing_util.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+/// Attach a remote OTel context parsed from a W3C `traceparent` header.
+///
+/// Returns a [`ContextGuard`] that keeps the remote context active on the
+/// current thread's OTel context stack.  Any `tracing` span created while
+/// the guard is alive will inherit the remote trace-id and parent span-id,
+/// because [`tracing_opentelemetry::OpenTelemetryLayer::on_new_span`] picks
+/// up the parent via [`opentelemetry::Context::current()`].
+///
+/// The expected format is: `00-{trace_id}-{span_id}-{trace_flags}`
+///
+/// Returns `None` if the string is malformed.
+///
+/// # Why not `set_parent`?
+///
+/// [`tracing_opentelemetry::OpenTelemetrySpanExt::set_parent`] relies on
+/// `downcast_ref::<WithContext>()` through the subscriber.  When the
+/// subscriber uses a [`tracing_subscriber::reload::Layer`] (as our
+/// `profiling::init_subscriber` does), `reload::Layer::downcast_raw`
+/// returns `None` for all types except `NoneLayerMarker`, so `set_parent`
+/// silently does nothing.  By instead pushing the remote context onto the
+/// OTel context stack *before* the tracing span is created, `on_new_span`
+/// reads it directly from `Context::current()`, bypassing the downcast
+/// entirely.
+#[cfg(feature = "profiling-otlp")]
+pub fn attach_remote_context(traceparent: &str) -> Option<opentelemetry::ContextGuard> {
+    use opentelemetry::Context;
+    use opentelemetry::trace::{
+        SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
+    };
+
+    let parts: Vec<&str> = traceparent.split('-').collect();
+    if parts.len() != 4 {
+        return None;
+    }
+
+    let trace_id = TraceId::from_hex(parts[1]).ok()?;
+    let span_id = SpanId::from_hex(parts[2]).ok()?;
+    let flags = u8::from_str_radix(parts[3], 16).unwrap_or(1);
+
+    let span_context = SpanContext::new(
+        trace_id,
+        span_id,
+        TraceFlags::new(flags),
+        true, // is_remote
+        TraceState::NONE,
+    );
+
+    let otel_ctx = Context::current().with_remote_span_context(span_context);
+    Some(otel_ctx.attach())
+}
+
+/// Create a tracing span with optional traceparent propagation.
+///
+/// When `profiling-otlp` is enabled, this attaches the remote OTel context
+/// (if any) before creating the span so it inherits the remote trace.
+/// When the feature is disabled, the traceparent is silently ignored.
+macro_rules! napi_span {
+    ($traceparent:expr, $span_name:expr) => {{
+        #[cfg(feature = "profiling-otlp")]
+        let _otel_guard = $traceparent
+            .as_deref()
+            .and_then(crate::tracing_util::attach_remote_context);
+        #[cfg(not(feature = "profiling-otlp"))]
+        let _ = $traceparent;
+        tracing::info_span!($span_name)
+    }};
+}
+pub(crate) use napi_span;

--- a/nodejs/src/tracing_util.rs
+++ b/nodejs/src/tracing_util.rs
@@ -36,9 +36,14 @@ pub fn attach_remote_context(traceparent: &str) -> Option<opentelemetry::Context
         return None;
     }
 
+    // Validate W3C traceparent format: version must be "00", correct field lengths
+    if parts[0] != "00" || parts[1].len() != 32 || parts[2].len() != 16 || parts[3].len() != 2 {
+        return None;
+    }
+
     let trace_id = TraceId::from_hex(parts[1]).ok()?;
     let span_id = SpanId::from_hex(parts[2]).ok()?;
-    let flags = u8::from_str_radix(parts[3], 16).unwrap_or(1);
+    let flags = u8::from_str_radix(parts[3], 16).ok()?;
 
     let span_context = SpanContext::new(
         trace_id,

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -50,7 +50,13 @@ lance-namespace = { workspace = true }
 lance-namespace-impls = { workspace = true }
 pin-project = { workspace = true }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
-log.workspace = true
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-appender-tracing = { workspace = true, optional = true }
 async-trait = "0"
 bytes = "1"
 futures.workspace = true
@@ -99,10 +105,20 @@ aws-smithy-runtime = { version = "1.9.1" }
 datafusion.workspace = true
 rstest = "0.23.0"
 test-log = "0.2"
+tracing-subscriber = { workspace = true }
 
 
 [features]
 default = []
+profiling = ["dep:tracing-subscriber"]
+profiling-otlp = [
+    "profiling",
+    "dep:tracing-opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry-appender-tracing",
+]
 aws = ["lance/aws", "lance-io/aws", "lance-namespace-impls/dir-aws"]
 oss = ["lance/oss", "lance-io/oss", "lance-namespace-impls/dir-oss"]
 gcs = ["lance/gcp", "lance-io/gcp", "lance-namespace-impls/dir-gcp"]

--- a/rust/lancedb/src/data/sanitize.rs
+++ b/rust/lancedb/src/data/sanitize.rs
@@ -13,8 +13,8 @@ use arrow_cast::{can_cast_types, cast};
 use arrow_schema::{ArrowError, DataType, Field, Schema};
 use half::f16;
 use lance_arrow::{DataTypeExt, FixedSizeListArrayExt};
-use log::warn;
 use num_traits::cast::AsPrimitive;
+use tracing::warn;
 
 use super::inspect::infer_dimension;
 use crate::error::Result;

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -341,7 +341,7 @@ impl ListingDatabase {
                 let table_base_uri = if let Some(store) = engine {
                     static WARN_ONCE: std::sync::Once = std::sync::Once::new();
                     WARN_ONCE.call_once(|| {
-                        log::warn!("Specifying engine is not a publicly supported feature in lancedb yet. THE API WILL CHANGE");
+                        tracing::warn!("Specifying engine is not a publicly supported feature in lancedb yet. THE API WILL CHANGE");
                     });
                     let old_scheme = url.scheme().to_string();
                     let new_scheme = format!("{}+{}", old_scheme, store);

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -168,7 +168,7 @@ impl PermutationBuilder {
             .unwrap_or_else(|_| DEFAULT_MEMORY_LIMIT.to_string())
             .parse::<usize>()
             .unwrap_or_else(|_| {
-                log::error!(
+                tracing::error!(
                     "Failed to parse LANCEDB_PERM_BUILDER_MEMORY_LIMIT, using default: {}",
                     DEFAULT_MEMORY_LIMIT
                 );

--- a/rust/lancedb/src/dataloader/permutation/shuffle.rs
+++ b/rust/lancedb/src/dataloader/permutation/shuffle.rs
@@ -113,7 +113,7 @@ impl Shuffler {
         let batches = data.try_collect::<Vec<_>>().await?;
         let batch = concat_batches(&schema, &batches)?;
         let shuffled = Self::shuffle_batch(&batch, &mut rng, self.config.clump_size.unwrap_or(1))?;
-        log::debug!("Shuffle job {}: in-memory shuffle complete", self.id);
+        tracing::debug!("Shuffle job {}: in-memory shuffle complete", self.id);
         Ok(Box::pin(SimpleRecordBatchStream::new(
             futures::stream::once(async move { Ok(shuffled) }),
             schema,
@@ -204,7 +204,7 @@ impl Shuffler {
         // Finish writing files
         for (file_idx, mut writer) in file_writers.into_iter().enumerate() {
             let num_written = writer.finish().await?;
-            log::debug!(
+            tracing::debug!(
                 "Shuffle job {}: wrote {} rows to file {}",
                 self.id,
                 num_written,
@@ -255,7 +255,7 @@ impl Shuffler {
         data: SendableRecordBatchStream,
         num_rows: u64,
     ) -> Result<SendableRecordBatchStream> {
-        log::debug!(
+        tracing::debug!(
             "Shuffle job {}: shuffling {} rows and {} columns",
             self.id,
             num_rows,

--- a/rust/lancedb/src/index/vector.rs
+++ b/rust/lancedb/src/index/vector.rs
@@ -315,7 +315,7 @@ pub(crate) fn suggested_num_sub_vectors(dim: u32) -> u32 {
     } else if dim.is_multiple_of(8) {
         dim / 8
     } else {
-        log::warn!(
+        tracing::warn!(
             "The dimension of the vector is not divisible by 8 or 16, \
                 which may cause performance degradation in PQ"
         );

--- a/rust/lancedb/src/index/waiter.rs
+++ b/rust/lancedb/src/index/waiter.rs
@@ -4,9 +4,9 @@
 use crate::Error;
 use crate::error::Result;
 use crate::table::BaseTable;
-use log::debug;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
+use tracing::debug;
 
 const DEFAULT_SLEEP_MS: u64 = 1000;
 const MAX_WAIT: Duration = Duration::from_secs(2 * 60 * 60);

--- a/rust/lancedb/src/io/object_store/io_tracking.rs
+++ b/rust/lancedb/src/io/object_store/io_tracking.rs
@@ -14,6 +14,7 @@ use object_store::{
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OSResult, UploadPart,
     path::Path,
 };
+use tracing::Instrument;
 
 #[derive(Debug, Default)]
 pub struct IoStats {
@@ -29,10 +30,66 @@ impl Display for IoStats {
     }
 }
 
+/// OTel metric instruments for I/O tracking.
+#[cfg(feature = "profiling-otlp")]
+#[derive(Clone, Debug)]
+struct IoMetrics {
+    read_bytes: opentelemetry::metrics::Histogram<u64>,
+    write_bytes: opentelemetry::metrics::Histogram<u64>,
+    read_count: opentelemetry::metrics::Counter<u64>,
+    write_count: opentelemetry::metrics::Counter<u64>,
+    read_duration: opentelemetry::metrics::Histogram<f64>,
+    write_duration: opentelemetry::metrics::Histogram<f64>,
+}
+
+#[cfg(feature = "profiling-otlp")]
+impl IoMetrics {
+    fn global() -> &'static Self {
+        static INSTANCE: std::sync::OnceLock<IoMetrics> = std::sync::OnceLock::new();
+        INSTANCE.get_or_init(Self::new)
+    }
+
+    fn new() -> Self {
+        let meter = opentelemetry::global::meter("lancedb");
+        Self {
+            read_bytes: meter
+                .u64_histogram("lancedb.io.read.bytes")
+                .with_unit("By")
+                .with_description("I/O read operation size distribution")
+                .build(),
+            write_bytes: meter
+                .u64_histogram("lancedb.io.write.bytes")
+                .with_unit("By")
+                .with_description("I/O write operation size distribution")
+                .build(),
+            read_count: meter
+                .u64_counter("lancedb.io.read.count")
+                .with_description("Total number of read I/O operations")
+                .build(),
+            write_count: meter
+                .u64_counter("lancedb.io.write.count")
+                .with_description("Total number of write I/O operations")
+                .build(),
+            read_duration: meter
+                .f64_histogram("lancedb.io.read.duration")
+                .with_unit("ms")
+                .with_description("Single read operation latency")
+                .build(),
+            write_duration: meter
+                .f64_histogram("lancedb.io.write.duration")
+                .with_unit("ms")
+                .with_description("Single write operation latency")
+                .build(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct IoTrackingStore {
     target: Arc<dyn ObjectStore>,
     stats: Arc<Mutex<IoStats>>,
+    #[cfg(feature = "profiling-otlp")]
+    metrics: Option<IoMetrics>,
 }
 
 impl Display for IoTrackingStore {
@@ -55,6 +112,8 @@ impl WrappingObjectStore for IoStatsHolder {
         Arc::new(IoTrackingStore {
             target,
             stats: self.0.clone(),
+            #[cfg(feature = "profiling-otlp")]
+            metrics: Some(IoMetrics::global().clone()),
         })
     }
 }
@@ -65,16 +124,40 @@ impl IoTrackingStore {
         (Arc::new(IoStatsHolder(stats.clone())), stats)
     }
 
-    fn record_read(&self, num_bytes: u64) {
+    fn record_read(&self, num_bytes: u64, op: &'static str, duration_ms: f64) {
         let mut stats = self.stats.lock().unwrap_or_else(|e| e.into_inner());
         stats.read_iops += 1;
         stats.read_bytes += num_bytes;
+
+        #[cfg(feature = "profiling-otlp")]
+        if let Some(ref m) = self.metrics {
+            let attrs = [opentelemetry::KeyValue::new("op", op)];
+            m.read_bytes.record(num_bytes, &attrs);
+            m.read_count.add(1, &attrs);
+            m.read_duration.record(duration_ms, &attrs);
+        }
+        #[cfg(not(feature = "profiling-otlp"))]
+        {
+            let _ = (op, duration_ms);
+        }
     }
 
-    fn record_write(&self, num_bytes: u64) {
+    fn record_write(&self, num_bytes: u64, op: &'static str, duration_ms: f64) {
         let mut stats = self.stats.lock().unwrap_or_else(|e| e.into_inner());
         stats.write_iops += 1;
         stats.write_bytes += num_bytes;
+
+        #[cfg(feature = "profiling-otlp")]
+        if let Some(ref m) = self.metrics {
+            let attrs = [opentelemetry::KeyValue::new("op", op)];
+            m.write_bytes.record(num_bytes, &attrs);
+            m.write_count.add(1, &attrs);
+            m.write_duration.record(duration_ms, &attrs);
+        }
+        #[cfg(not(feature = "profiling-otlp"))]
+        {
+            let _ = (op, duration_ms);
+        }
     }
 }
 
@@ -82,8 +165,15 @@ impl IoTrackingStore {
 #[deny(clippy::missing_trait_methods)]
 impl ObjectStore for IoTrackingStore {
     async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
-        self.record_write(bytes.content_length() as u64);
-        self.target.put(location, bytes).await
+        let num_bytes = bytes.content_length() as u64;
+        let start = std::time::Instant::now();
+        let result = self
+            .target
+            .put(location, bytes)
+            .instrument(tracing::info_span!("lancedb.io.put", path = %location, bytes = num_bytes))
+            .await;
+        self.record_write(num_bytes, "put", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 
     async fn put_opts(
@@ -92,8 +182,15 @@ impl ObjectStore for IoTrackingStore {
         bytes: PutPayload,
         opts: PutOptions,
     ) -> OSResult<PutResult> {
-        self.record_write(bytes.content_length() as u64);
-        self.target.put_opts(location, bytes, opts).await
+        let num_bytes = bytes.content_length() as u64;
+        let start = std::time::Instant::now();
+        let result = self
+            .target
+            .put_opts(location, bytes, opts)
+            .instrument(tracing::info_span!("lancedb.io.put", path = %location, bytes = num_bytes))
+            .await;
+        self.record_write(num_bytes, "put", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 
     async fn put_multipart(&self, location: &Path) -> OSResult<Box<dyn MultipartUpload>> {
@@ -101,6 +198,8 @@ impl ObjectStore for IoTrackingStore {
         Ok(Box::new(IoTrackingMultipartUpload {
             target,
             stats: self.stats.clone(),
+            #[cfg(feature = "profiling-otlp")]
+            metrics: self.metrics.clone(),
         }))
     }
 
@@ -113,31 +212,52 @@ impl ObjectStore for IoTrackingStore {
         Ok(Box::new(IoTrackingMultipartUpload {
             target,
             stats: self.stats.clone(),
+            #[cfg(feature = "profiling-otlp")]
+            metrics: self.metrics.clone(),
         }))
     }
 
     async fn get(&self, location: &Path) -> OSResult<GetResult> {
-        let result = self.target.get(location).await;
+        let start = std::time::Instant::now();
+        let result = self
+            .target
+            .get(location)
+            .instrument(tracing::info_span!("lancedb.io.get", path = %location))
+            .await;
         if let Ok(result) = &result {
             let num_bytes = result.range.end - result.range.start;
-            self.record_read(num_bytes);
+            self.record_read(num_bytes, "get", start.elapsed().as_secs_f64() * 1000.0);
         }
         result
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
-        let result = self.target.get_opts(location, options).await;
+        let start = std::time::Instant::now();
+        let result = self
+            .target
+            .get_opts(location, options)
+            .instrument(tracing::info_span!("lancedb.io.get", path = %location))
+            .await;
         if let Ok(result) = &result {
             let num_bytes = result.range.end - result.range.start;
-            self.record_read(num_bytes);
+            self.record_read(num_bytes, "get", start.elapsed().as_secs_f64() * 1000.0);
         }
         result
     }
 
     async fn get_range(&self, location: &Path, range: std::ops::Range<u64>) -> OSResult<Bytes> {
-        let result = self.target.get_range(location, range).await;
+        let start = std::time::Instant::now();
+        let result = self
+            .target
+            .get_range(location, range)
+            .instrument(tracing::info_span!("lancedb.io.get_range", path = %location))
+            .await;
         if let Ok(result) = &result {
-            self.record_read(result.len() as u64);
+            self.record_read(
+                result.len() as u64,
+                "get_range",
+                start.elapsed().as_secs_f64() * 1000.0,
+            );
         }
         result
     }
@@ -147,21 +267,32 @@ impl ObjectStore for IoTrackingStore {
         location: &Path,
         ranges: &[std::ops::Range<u64>],
     ) -> OSResult<Vec<Bytes>> {
-        let result = self.target.get_ranges(location, ranges).await;
+        let start = std::time::Instant::now();
+        let result = self.target.get_ranges(location, ranges)
+            .instrument(tracing::info_span!("lancedb.io.get_ranges", path = %location, num_ranges = ranges.len()))
+            .await;
         if let Ok(result) = &result {
-            self.record_read(result.iter().map(|b| b.len() as u64).sum());
+            self.record_read(
+                result.iter().map(|b| b.len() as u64).sum(),
+                "get_ranges",
+                start.elapsed().as_secs_f64() * 1000.0,
+            );
         }
         result
     }
 
     async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
-        self.record_read(0);
-        self.target.head(location).await
+        let start = std::time::Instant::now();
+        let result = self.target.head(location).await;
+        self.record_read(0, "head", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 
     async fn delete(&self, location: &Path) -> OSResult<()> {
-        self.record_write(0);
-        self.target.delete(location).await
+        let start = std::time::Instant::now();
+        let result = self.target.delete(location).await;
+        self.record_write(0, "delete", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 
     fn delete_stream<'a>(
@@ -171,8 +302,10 @@ impl ObjectStore for IoTrackingStore {
         self.target.delete_stream(locations)
     }
 
+    // list/list_with_offset return a stream whose lifetime we cannot time
+    // end-to-end, so duration is recorded as 0.0.
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
-        self.record_read(0);
+        self.record_read(0, "list", 0.0);
         self.target.list(prefix)
     }
 
@@ -181,33 +314,44 @@ impl ObjectStore for IoTrackingStore {
         prefix: Option<&Path>,
         offset: &Path,
     ) -> BoxStream<'static, OSResult<ObjectMeta>> {
-        self.record_read(0);
+        // Returns a stream — duration cannot be measured, recorded as 0.0.
+        self.record_read(0, "list", 0.0);
         self.target.list_with_offset(prefix, offset)
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
-        self.record_read(0);
-        self.target.list_with_delimiter(prefix).await
+        let start = std::time::Instant::now();
+        let result = self.target.list_with_delimiter(prefix).await;
+        self.record_read(0, "list", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.record_write(0);
-        self.target.copy(from, to).await
+        let start = std::time::Instant::now();
+        let result = self.target.copy(from, to).await;
+        self.record_write(0, "copy", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.record_write(0);
-        self.target.rename(from, to).await
+        let start = std::time::Instant::now();
+        let result = self.target.rename(from, to).await;
+        self.record_write(0, "rename", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.record_write(0);
-        self.target.rename_if_not_exists(from, to).await
+        let start = std::time::Instant::now();
+        let result = self.target.rename_if_not_exists(from, to).await;
+        self.record_write(0, "rename", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.record_write(0);
-        self.target.copy_if_not_exists(from, to).await
+        let start = std::time::Instant::now();
+        let result = self.target.copy_if_not_exists(from, to).await;
+        self.record_write(0, "copy", start.elapsed().as_secs_f64() * 1000.0);
+        result
     }
 }
 
@@ -215,6 +359,8 @@ impl ObjectStore for IoTrackingStore {
 struct IoTrackingMultipartUpload {
     target: Box<dyn MultipartUpload>,
     stats: Arc<Mutex<IoStats>>,
+    #[cfg(feature = "profiling-otlp")]
+    metrics: Option<IoMetrics>,
 }
 
 #[async_trait::async_trait]
@@ -228,12 +374,30 @@ impl MultipartUpload for IoTrackingMultipartUpload {
     }
 
     fn put_part(&mut self, payload: PutPayload) -> UploadPart {
-        {
-            let mut stats = self.stats.lock().unwrap_or_else(|e| e.into_inner());
-            stats.write_iops += 1;
-            stats.write_bytes += payload.content_length() as u64;
-        }
-        self.target.put_part(payload)
+        let num_bytes = payload.content_length() as u64;
+        let stats = self.stats.clone();
+        #[cfg(feature = "profiling-otlp")]
+        let metrics = self.metrics.clone();
+        let fut = self.target.put_part(payload);
+        #[cfg(feature = "profiling-otlp")]
+        let start = std::time::Instant::now();
+        Box::pin(async move {
+            let result = fut.await;
+            {
+                let mut s = stats.lock().unwrap_or_else(|e| e.into_inner());
+                s.write_iops += 1;
+                s.write_bytes += num_bytes;
+            }
+            #[cfg(feature = "profiling-otlp")]
+            if let Some(ref m) = metrics {
+                let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
+                let attrs = [opentelemetry::KeyValue::new("op", "put_multipart")];
+                m.write_bytes.record(num_bytes, &attrs);
+                m.write_count.add(1, &attrs);
+                m.write_duration.record(duration_ms, &attrs);
+            }
+            result
+        })
     }
 }
 
@@ -258,12 +422,14 @@ mod tests {
         let store = IoTrackingStore {
             target: Arc::new(object_store::memory::InMemory::new()),
             stats: stats.clone(),
+            #[cfg(feature = "profiling-otlp")]
+            metrics: None,
         };
 
         poison_stats(&stats);
 
         // record_read should not panic
-        store.record_read(1024);
+        store.record_read(1024, "get", 0.0);
 
         // Verify the stats were updated despite poisoning
         let s = stats.lock().unwrap_or_else(|e| e.into_inner());
@@ -277,15 +443,88 @@ mod tests {
         let store = IoTrackingStore {
             target: Arc::new(object_store::memory::InMemory::new()),
             stats: stats.clone(),
+            #[cfg(feature = "profiling-otlp")]
+            metrics: None,
         };
 
         poison_stats(&stats);
 
         // record_write should not panic
-        store.record_write(2048);
+        store.record_write(2048, "put", 0.0);
 
         let s = stats.lock().unwrap_or_else(|e| e.into_inner());
         assert_eq!(s.write_iops, 1);
         assert_eq!(s.write_bytes, 2048);
+    }
+
+    #[tokio::test]
+    async fn test_io_tracking_produces_tracing_spans() {
+        use std::sync::Mutex as StdMutex;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Debug, Clone)]
+        struct SpanInfo {
+            name: String,
+            id: u64,
+            #[allow(dead_code)] // recorded for debugging parent-child relationships
+            parent_id: Option<u64>,
+        }
+        let spans: Arc<StdMutex<Vec<SpanInfo>>> = Arc::new(StdMutex::new(Vec::new()));
+        let spans_clone = spans.clone();
+
+        struct SpanCollector(Arc<StdMutex<Vec<SpanInfo>>>);
+        impl<S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>>
+            tracing_subscriber::Layer<S> for SpanCollector
+        {
+            fn on_new_span(
+                &self,
+                attrs: &tracing::span::Attributes<'_>,
+                id: &tracing::span::Id,
+                ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let parent_id = attrs
+                    .parent()
+                    .cloned()
+                    .or_else(|| ctx.current_span().id().cloned())
+                    .map(|pid| pid.into_u64());
+                self.0.lock().unwrap().push(SpanInfo {
+                    name: attrs.metadata().name().to_string(),
+                    id: id.into_u64(),
+                    parent_id,
+                });
+            }
+        }
+
+        let subscriber = tracing_subscriber::registry().with(SpanCollector(spans_clone));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let store = IoTrackingStore {
+            target: Arc::new(object_store::memory::InMemory::new()),
+            stats: Arc::new(Mutex::new(IoStats::default())),
+            #[cfg(feature = "profiling-otlp")]
+            metrics: None,
+        };
+
+        // Write and read to trigger spans
+        let data = PutPayload::from_static(b"hello");
+        store.put(&Path::from("test.txt"), data).await.unwrap();
+        let _ = store.get(&Path::from("test.txt")).await.unwrap();
+
+        let collected = spans.lock().unwrap();
+        assert!(
+            collected.iter().any(|s| s.name == "lancedb.io.put"),
+            "Expected 'lancedb.io.put' span, found: {:?}",
+            collected.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+        assert!(
+            collected.iter().any(|s| s.name == "lancedb.io.get"),
+            "Expected 'lancedb.io.get' span, found: {:?}",
+            collected.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+
+        // Verify all spans have valid IDs
+        for span in collected.iter() {
+            assert!(span.id > 0, "Span '{}' has invalid id 0", span.name);
+        }
     }
 }

--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -173,6 +173,8 @@ pub mod io;
 pub mod ipc;
 #[cfg(feature = "polars")]
 mod polars_arrow_convertors;
+#[cfg(any(feature = "profiling", feature = "profiling-otlp"))]
+pub mod profiling;
 pub mod query;
 pub mod rerankers;
 pub mod table;

--- a/rust/lancedb/src/profiling.rs
+++ b/rust/lancedb/src/profiling.rs
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! Performance profiling and observability support.
+//!
+//! This module provides helpers to initialize [`tracing`] subscribers for
+//! structured logging and, optionally, OpenTelemetry export of traces, metrics,
+//! and logs.
+//!
+//! # Feature flags
+//!
+//! * `profiling` — enables local fmt/json subscriber helpers.
+//! * `profiling-otlp` — enables full OTLP export (traces + metrics + logs).
+//!
+//! # Hot-reload pattern
+//!
+//! Use [`init_subscriber`] to install a global subscriber with hot-reload
+//! support, then call [`upgrade_to_otlp`] later to add OTLP export without
+//! replacing the global subscriber.
+//!
+//! ```ignore
+//! use lancedb::profiling::{init_subscriber, upgrade_to_otlp, OtlpConfig};
+//!
+//! let handle = init_subscriber();
+//! // ... later, when ready to enable OTLP:
+//! let guard = upgrade_to_otlp(&handle, OtlpConfig::default()).unwrap();
+//! ```
+
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{Layer, Registry, reload};
+
+type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync>;
+
+/// A composite layer that delegates to multiple inner boxed layers and
+/// applies a [`LevelFilter`] to gate which events/spans are processed.
+///
+/// This avoids using `tracing_subscriber::filter::Filtered` (which requires
+/// a `FilterId` assigned during subscriber registration and is incompatible
+/// with [`reload::Layer`] hot-swapping).
+struct MultiLayer {
+    level: LevelFilter,
+    layers: Vec<BoxedLayer>,
+}
+
+impl Layer<Registry> for MultiLayer {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>, _ctx: Context<'_, Registry>) -> bool {
+        metadata.level() <= &self.level
+    }
+
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, Registry>,
+    ) {
+        for layer in &self.layers {
+            layer.on_new_span(attrs, id, ctx.clone());
+        }
+    }
+
+    fn on_record(
+        &self,
+        span: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        ctx: Context<'_, Registry>,
+    ) {
+        for layer in &self.layers {
+            layer.on_record(span, values, ctx.clone());
+        }
+    }
+
+    fn on_follows_from(
+        &self,
+        span: &tracing::span::Id,
+        follows: &tracing::span::Id,
+        ctx: Context<'_, Registry>,
+    ) {
+        for layer in &self.layers {
+            layer.on_follows_from(span, follows, ctx.clone());
+        }
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, Registry>) {
+        for layer in &self.layers {
+            layer.on_event(event, ctx.clone());
+        }
+    }
+
+    fn on_enter(&self, id: &tracing::span::Id, ctx: Context<'_, Registry>) {
+        for layer in &self.layers {
+            layer.on_enter(id, ctx.clone());
+        }
+    }
+
+    fn on_exit(&self, id: &tracing::span::Id, ctx: Context<'_, Registry>) {
+        for layer in &self.layers {
+            layer.on_exit(id, ctx.clone());
+        }
+    }
+
+    fn on_close(&self, id: tracing::span::Id, ctx: Context<'_, Registry>) {
+        for layer in &self.layers {
+            layer.on_close(id.clone(), ctx.clone());
+        }
+    }
+
+    #[doc(hidden)]
+    unsafe fn downcast_raw(&self, id: std::any::TypeId) -> Option<*const ()> {
+        if id == std::any::TypeId::of::<Self>() {
+            return Some(self as *const _ as *const ());
+        }
+        // SAFETY: The inner layers live as long as this `MultiLayer`. When the
+        // `reload::Layer` hot-swaps the `MultiLayer`, the old instance is kept
+        // alive (behind an `Arc` inside `reload`) until all outstanding span
+        // references are dropped, so pointers returned here remain valid for
+        // the lifetime of any span that holds them.
+        //
+        // Forwarding is necessary so that `tracing_opentelemetry::WithContext`
+        // can be found by `set_parent()` through the reload boundary.
+        self.layers
+            .iter()
+            .find_map(|l| unsafe { l.downcast_raw(id) })
+    }
+}
+
+/// Parse `LANCEDB_LOG` env var as a [`LevelFilter`].
+///
+/// Supports simple level names: "trace", "debug", "info", "warn", "error",
+/// "off". For advanced per-module filtering (e.g. `lancedb=debug,lance=info`),
+/// use [`init_fmt_subscriber`] which accepts the full [`EnvFilter`] syntax.
+///
+/// Defaults to [`LevelFilter::WARN`] if unset or unparseable.
+fn level_from_env() -> LevelFilter {
+    std::env::var("LANCEDB_LOG")
+        .ok()
+        .and_then(|s| s.parse::<LevelFilter>().ok())
+        .unwrap_or(LevelFilter::WARN)
+}
+
+/// Handle for hot-reloading the tracing subscriber's inner layers.
+///
+/// Returned by [`init_subscriber`]. Pass to [`upgrade_to_otlp`] to add
+/// OTLP export without replacing the global subscriber.
+pub struct ReloadHandle(reload::Handle<MultiLayer, Registry>);
+
+/// Install a global tracing subscriber with hot-reload support.
+///
+/// The initial subscriber uses a fmt layer filtered by the `LANCEDB_LOG`
+/// environment variable (defaults to `warn`). Returns a [`ReloadHandle`]
+/// that can later be passed to [`upgrade_to_otlp`] to add OTLP export.
+///
+/// This function should be called exactly once, typically at process
+/// startup or module init.
+pub fn init_subscriber() -> ReloadHandle {
+    let level = level_from_env();
+    let fmt_layer: BoxedLayer = Box::new(tracing_subscriber::fmt::layer());
+    let initial = MultiLayer {
+        level,
+        layers: vec![fmt_layer],
+    };
+    let (reload_layer, handle) = reload::Layer::new(initial);
+    tracing_subscriber::registry()
+        .with(reload_layer)
+        .try_init()
+        .ok(); // If another subscriber is already set, silently ignore
+    ReloadHandle(handle)
+}
+
+/// Initialize a human-readable fmt subscriber.
+///
+/// The filter is controlled by the `LANCEDB_LOG` environment variable
+/// (defaults to `warn`).
+pub fn init_fmt_subscriber() {
+    let filter = tracing_subscriber::EnvFilter::try_from_env("LANCEDB_LOG")
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .try_init()
+        .ok();
+}
+
+/// Initialize a JSON-formatted subscriber.
+///
+/// The filter is controlled by the `LANCEDB_LOG` environment variable
+/// (defaults to `warn`).
+pub fn init_json_subscriber() {
+    let filter = tracing_subscriber::EnvFilter::try_from_env("LANCEDB_LOG")
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(filter)
+        .try_init()
+        .ok();
+}
+
+/// OTLP transport protocol.
+#[cfg(feature = "profiling-otlp")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OtlpProtocol {
+    /// gRPC (port 4317 by convention)
+    Grpc,
+    /// HTTP/protobuf (port 4318 by convention)
+    #[default]
+    Http,
+}
+
+/// Configuration for OTLP export.
+#[cfg(feature = "profiling-otlp")]
+#[derive(Debug, Clone)]
+pub struct OtlpConfig {
+    /// OTLP collector endpoint.
+    ///
+    /// Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT` env var, then
+    /// `http://localhost:4318`.
+    pub endpoint: String,
+    /// The `service.name` resource attribute.
+    ///
+    /// Falls back to `OTEL_SERVICE_NAME` env var, then `lancedb`.
+    pub service_name: String,
+    /// Transport protocol.
+    pub protocol: OtlpProtocol,
+}
+
+#[cfg(feature = "profiling-otlp")]
+impl Default for OtlpConfig {
+    fn default() -> Self {
+        let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .unwrap_or_else(|_| "http://localhost:4318".to_string());
+        let service_name =
+            std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "lancedb".to_string());
+        Self {
+            endpoint,
+            service_name,
+            protocol: OtlpProtocol::default(),
+        }
+    }
+}
+
+/// Guard returned by [`upgrade_to_otlp`] / [`init_otlp`].
+///
+/// Dropping this guard will flush and shut down all OTLP exporters.
+/// For explicit control, call [`OtlpGuard::shutdown`] before process exit.
+#[cfg(feature = "profiling-otlp")]
+pub struct OtlpGuard {
+    tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    meter_provider: Option<opentelemetry_sdk::metrics::SdkMeterProvider>,
+    log_provider: Option<opentelemetry_sdk::logs::SdkLoggerProvider>,
+}
+
+#[cfg(feature = "profiling-otlp")]
+impl OtlpGuard {
+    fn shutdown_inner(&mut self) {
+        if let Some(tp) = self.tracer_provider.take()
+            && let Err(e) = tp.shutdown()
+        {
+            eprintln!("lancedb profiling: failed to shutdown tracer provider: {e}");
+        }
+        if let Some(mp) = self.meter_provider.take()
+            && let Err(e) = mp.shutdown()
+        {
+            eprintln!("lancedb profiling: failed to shutdown meter provider: {e}");
+        }
+        if let Some(lp) = self.log_provider.take()
+            && let Err(e) = lp.shutdown()
+        {
+            eprintln!("lancedb profiling: failed to shutdown log provider: {e}");
+        }
+    }
+
+    /// Flush and shut down all OTLP exporters.
+    pub fn shutdown(mut self) {
+        self.shutdown_inner();
+    }
+}
+
+#[cfg(feature = "profiling-otlp")]
+impl Drop for OtlpGuard {
+    fn drop(&mut self) {
+        self.shutdown_inner();
+    }
+}
+
+/// Upgrade the subscriber to include OTLP export of traces, metrics, and logs.
+///
+/// This hot-swaps the inner layers of the subscriber installed by
+/// [`init_subscriber`], without replacing the global subscriber. The level
+/// filter is changed to [`LevelFilter::TRACE`] so that all spans and events
+/// are captured by the OTLP exporters.
+///
+/// OTel providers (tracer, meter, logger) are registered globally via
+/// [`opentelemetry::global`].
+///
+/// Returns an [`OtlpGuard`] whose [`shutdown`](OtlpGuard::shutdown) method
+/// should be called before exit to flush pending data.
+#[cfg(feature = "profiling-otlp")]
+pub fn upgrade_to_otlp(
+    handle: &ReloadHandle,
+    config: OtlpConfig,
+) -> Result<OtlpGuard, Box<dyn std::error::Error>> {
+    use opentelemetry::KeyValue;
+    use opentelemetry::trace::TracerProvider;
+    use opentelemetry_otlp::WithExportConfig;
+    use opentelemetry_sdk::Resource;
+
+    let resource = Resource::builder()
+        .with_attributes([KeyValue::new(
+            opentelemetry::Key::new("service.name"),
+            opentelemetry::Value::from(config.service_name.clone()),
+        )])
+        .build();
+
+    let base = config.endpoint.trim_end_matches('/');
+
+    // --- Traces ---
+    let trace_exporter = match config.protocol {
+        OtlpProtocol::Http => opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_endpoint(format!("{base}/v1/traces"))
+            .build()?,
+        OtlpProtocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(base)
+            .build()?,
+    };
+    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_resource(resource.clone())
+        .with_batch_exporter(trace_exporter)
+        .build();
+    let tracer = tracer_provider.tracer("lancedb");
+    let _prev = opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+    let traces_layer: BoxedLayer = Box::new(tracing_opentelemetry::layer().with_tracer(tracer));
+
+    // --- Metrics ---
+    let metrics_exporter = match config.protocol {
+        OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_endpoint(format!("{base}/v1/metrics"))
+            .build()?,
+        OtlpProtocol::Grpc => opentelemetry_otlp::MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(base)
+            .build()?,
+    };
+    let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .with_resource(resource.clone())
+        .with_periodic_exporter(metrics_exporter)
+        .build();
+    opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+    // --- Logs ---
+    let log_exporter = match config.protocol {
+        OtlpProtocol::Http => opentelemetry_otlp::LogExporter::builder()
+            .with_http()
+            .with_endpoint(format!("{base}/v1/logs"))
+            .build()?,
+        OtlpProtocol::Grpc => opentelemetry_otlp::LogExporter::builder()
+            .with_tonic()
+            .with_endpoint(base)
+            .build()?,
+    };
+    let log_provider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(log_exporter)
+        .build();
+    let logs_layer: BoxedLayer = Box::new(
+        opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(&log_provider),
+    );
+
+    // --- Assemble new layer stack ---
+    // Use TRACE level so all spans/events reach the OTLP exporters.
+    // The fmt layer (console output) keeps its own level filter so it is not
+    // flooded by TRACE-level events from the OTLP pipeline.
+    let mut layers: Vec<BoxedLayer> = vec![traces_layer, logs_layer];
+    if std::env::var("LANCEDB_LOG").is_ok() {
+        let fmt_level = level_from_env();
+        layers.push(Box::new(
+            tracing_subscriber::fmt::layer().with_filter(fmt_level),
+        ));
+    }
+
+    let upgraded = MultiLayer {
+        level: LevelFilter::TRACE,
+        layers,
+    };
+
+    // --- Hot-swap ---
+    handle
+        .0
+        .reload(upgraded)
+        .map_err(|e| format!("failed to reload tracing layers: {e}"))?;
+
+    Ok(OtlpGuard {
+        tracer_provider: Some(tracer_provider),
+        meter_provider: Some(meter_provider),
+        log_provider: Some(log_provider),
+    })
+}
+
+/// Initialize the three-signal OTLP pipeline (traces + metrics + logs).
+///
+/// This is a convenience function that combines [`init_subscriber`] and
+/// [`upgrade_to_otlp`] in one call. Prefer the two-step pattern when you
+/// need the subscriber to be available before OTLP is configured (e.g.
+/// in Node.js module init).
+///
+/// Returns an [`OtlpGuard`] whose [`shutdown`](OtlpGuard::shutdown) method
+/// must be called before exit to flush pending data.
+#[cfg(feature = "profiling-otlp")]
+pub fn init_otlp(config: OtlpConfig) -> Result<OtlpGuard, Box<dyn std::error::Error>> {
+    let handle = init_subscriber();
+    upgrade_to_otlp(&handle, config)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_init_fmt_subscriber_does_not_panic() {
+        super::init_fmt_subscriber();
+    }
+
+    #[test]
+    fn test_init_json_subscriber_does_not_panic() {
+        super::init_json_subscriber();
+    }
+
+    #[test]
+    fn test_init_subscriber_returns_handle() {
+        let _handle = super::init_subscriber();
+    }
+
+    #[cfg(feature = "profiling-otlp")]
+    #[test]
+    fn test_otlp_config_default() {
+        let config = super::OtlpConfig::default();
+        assert!(!config.endpoint.is_empty());
+        assert!(!config.service_name.is_empty());
+        assert_eq!(config.protocol, super::OtlpProtocol::Http);
+    }
+}

--- a/rust/lancedb/src/query.rs
+++ b/rust/lancedb/src/query.rs
@@ -870,6 +870,11 @@ impl ExecutableQuery for Query {
         self.parent.clone().create_plan(&req, options).await
     }
 
+    #[tracing::instrument(
+        name = "lancedb.query.execute",
+        skip_all,
+        fields(query_type = "filter")
+    )]
     async fn execute_with_options(
         &self,
         options: QueryExecutionOptions,
@@ -1349,6 +1354,7 @@ impl ExecutableQuery for VectorQuery {
         self.parent.clone().create_plan(&query, options).await
     }
 
+    #[tracing::instrument(name = "lancedb.query.execute", skip_all, fields(query_type = "vector", top_k = self.request.base.limit.unwrap_or(DEFAULT_TOP_K)))]
     async fn execute_with_options(
         &self,
         options: QueryExecutionOptions,
@@ -1497,6 +1503,7 @@ impl ExecutableQuery for TakeQuery {
         self.parent.clone().create_plan(&req, options).await
     }
 
+    #[tracing::instrument(name = "lancedb.query.execute", skip_all, fields(query_type = "take"))]
     async fn execute_with_options(
         &self,
         options: QueryExecutionOptions,

--- a/rust/lancedb/src/query/hybrid.rs
+++ b/rust/lancedb/src/query/hybrid.rs
@@ -194,8 +194,14 @@ impl OriginalScores {
         if batch.num_rows() == 0 {
             return None;
         }
-        let row_ids: UInt64Array = downcast_array(batch.column_by_name(ROW_ID)?);
-        let scores: Float32Array = downcast_array(batch.column_by_name(score_column)?);
+        let row_ids = batch
+            .column_by_name(ROW_ID)?
+            .as_any()
+            .downcast_ref::<UInt64Array>()?;
+        let scores = batch
+            .column_by_name(score_column)?
+            .as_any()
+            .downcast_ref::<Float32Array>()?;
         // Use `entry().or_insert()` so that for duplicate ROW_IDs the *first*
         // occurrence wins, consistent with `dedup_by_row_id` which also keeps
         // the first occurrence.  (`HashMap::collect` would keep the *last*.)
@@ -227,19 +233,27 @@ pub fn restore_original_scores(
         return Ok(results); // column not present, nothing to restore
     };
 
-    let row_ids: UInt64Array =
-        downcast_array(
-            results
-                .column_by_name(ROW_ID)
-                .ok_or_else(|| Error::Runtime {
-                    message: format!(
-                        "cannot restore scores: {} column missing from results",
-                        ROW_ID
-                    ),
-                })?,
-        );
+    let row_ids = results
+        .column_by_name(ROW_ID)
+        .ok_or_else(|| Error::Runtime {
+            message: format!(
+                "cannot restore scores: {} column missing from results",
+                ROW_ID
+            ),
+        })?
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .ok_or_else(|| Error::Runtime {
+            message: format!("{} column is not UInt64", ROW_ID),
+        })?;
 
-    let current: Float32Array = downcast_array(results.column(col_idx));
+    let current = results
+        .column(col_idx)
+        .as_any()
+        .downcast_ref::<Float32Array>()
+        .ok_or_else(|| Error::Runtime {
+            message: format!("{} column is not Float32", score_column),
+        })?;
     let restored = Float32Array::from_iter(row_ids.values().iter().enumerate().map(|(i, &id)| {
         match original.map.get(&id) {
             Some(val) => *val, // original value (Some(f32) or None/null)

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -500,6 +500,7 @@ impl Table {
     /// # Arguments
     ///
     /// * `filter` if present, only count rows matching the filter
+    #[tracing::instrument(name = "lancedb.table.count_rows", skip_all, fields(table = self.name()))]
     pub async fn count_rows(&self, filter: Option<String>) -> Result<usize> {
         self.inner.count_rows(filter.map(Filter::Sql)).await
     }
@@ -510,6 +511,7 @@ impl Table {
     ///
     /// * `data` data to be added to the Table
     /// * `options` options to control how data is added
+    #[tracing::instrument(name = "lancedb.table.add", skip_all, fields(table = self.name()))]
     pub fn add<T: Scannable + 'static>(&self, data: T) -> AddDataBuilder {
         AddDataBuilder::new(
             self.inner.clone(),
@@ -532,6 +534,7 @@ impl Table {
     /// you are updating many rows (with different ids) then you will get
     /// better performance with a single [`merge_insert`] call instead of
     /// repeatedly calilng this method.
+    #[tracing::instrument(name = "lancedb.table.update", skip_all, fields(table = self.name()))]
     pub fn update(&self) -> UpdateBuilder {
         UpdateBuilder::new(self.inner.clone())
     }
@@ -580,6 +583,7 @@ impl Table {
     /// tbl.delete("id > 5").await.unwrap();
     /// # });
     /// ```
+    #[tracing::instrument(name = "lancedb.table.delete", skip_all, fields(table = self.name(), predicate))]
     pub async fn delete(&self, predicate: &str) -> Result<DeleteResult> {
         self.inner.delete(predicate).await
     }
@@ -645,6 +649,7 @@ impl Table {
     ///     .unwrap();
     /// # });
     /// ```
+    #[tracing::instrument(name = "lancedb.table.create_index", skip_all, fields(table = self.name()))]
     pub fn create_index(&self, columns: &[impl AsRef<str>], index: Index) -> IndexBuilder {
         IndexBuilder::new(
             self.inner.clone(),
@@ -753,6 +758,7 @@ impl Table {
     /// merge_insert.execute(Box::new(new_data)).await.unwrap();
     /// # });
     /// ```
+    #[tracing::instrument(name = "lancedb.table.merge_insert", skip_all, fields(table = self.name()))]
     pub fn merge_insert(&self, on: &[&str]) -> MergeInsertBuilder {
         MergeInsertBuilder::new(
             self.inner.clone(),
@@ -847,6 +853,7 @@ impl Table {
     /// let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
     /// # });
     /// ```
+    #[tracing::instrument(name = "lancedb.table.query", skip_all, fields(table = self.name()))]
     pub fn query(&self) -> Query {
         Query::new(self.inner.clone())
     }
@@ -924,6 +931,7 @@ impl Table {
     /// optimize should be run frequently.  A good rule of thumb is to run optimize if
     /// you have added or modified 100,000 or more records or run more than 20 data
     /// modification operations.
+    #[tracing::instrument(name = "lancedb.table.optimize", skip_all, fields(table = self.name()))]
     pub async fn optimize(&self, action: OptimizeAction) -> Result<OptimizeStats> {
         self.inner.optimize(action).await
     }
@@ -2188,6 +2196,7 @@ impl BaseTable for NativeTable {
         TableDefinition::try_from_rich_schema(schema)
     }
 
+    #[tracing::instrument(name = "lancedb.native.count_rows", skip_all, fields(table = self.name))]
     async fn count_rows(&self, filter: Option<Filter>) -> Result<usize> {
         let dataset = self.dataset.get().await?;
         match filter {
@@ -2199,6 +2208,7 @@ impl BaseTable for NativeTable {
         }
     }
 
+    #[tracing::instrument(name = "lancedb.native.add", skip_all, fields(table = self.name))]
     async fn add(&self, mut add: AddDataBuilder) -> Result<AddResult> {
         let table_def = self.table_definition().await?;
 
@@ -2290,6 +2300,7 @@ impl BaseTable for NativeTable {
         Ok(AddResult { version })
     }
 
+    #[tracing::instrument(name = "lancedb.native.create_index", skip_all, fields(table = self.name))]
     async fn create_index(&self, opts: IndexBuilder) -> Result<()> {
         if opts.columns.len() != 1 {
             return Err(Error::Schema {
@@ -2331,6 +2342,7 @@ impl BaseTable for NativeTable {
         Ok(dataset.prewarm_index(index_name).await?)
     }
 
+    #[tracing::instrument(name = "lancedb.native.update", skip_all, fields(table = self.name))]
     async fn update(&self, update: UpdateBuilder) -> Result<UpdateResult> {
         // Delegate to the submodule implementation
         update::execute_update(self, update).await
@@ -2344,6 +2356,7 @@ impl BaseTable for NativeTable {
         query::create_plan(self, query, options).await
     }
 
+    #[tracing::instrument(name = "lancedb.native.query", skip_all, fields(table = self.name))]
     async fn query(
         &self,
         query: &AnyQuery,
@@ -2360,6 +2373,7 @@ impl BaseTable for NativeTable {
         query::analyze_query_plan(self, query, options).await
     }
 
+    #[tracing::instrument(name = "lancedb.native.merge_insert", skip_all, fields(table = self.name))]
     async fn merge_insert(
         &self,
         params: MergeInsertBuilder,
@@ -2368,6 +2382,7 @@ impl BaseTable for NativeTable {
         merge::execute_merge_insert(self, params, new_data).await
     }
 
+    #[tracing::instrument(name = "lancedb.native.delete", skip_all, fields(table = self.name, predicate))]
     /// Delete rows from the table
     async fn delete(&self, predicate: &str) -> Result<DeleteResult> {
         // Delegate to the submodule implementation
@@ -2380,6 +2395,7 @@ impl BaseTable for NativeTable {
         }))
     }
 
+    #[tracing::instrument(name = "lancedb.native.optimize", skip_all, fields(table = self.name))]
     async fn optimize(&self, action: OptimizeAction) -> Result<OptimizeStats> {
         // Delegate to the submodule implementation
         optimize::execute_optimize(self, action).await
@@ -2414,7 +2430,7 @@ impl BaseTable for NativeTable {
             let stats = match dataset.index_statistics(idx.name.as_str()).await {
                 Ok(stats) => stats,
                 Err(e) => {
-                    log::warn!("Failed to get statistics for index {} ({}): {}", idx.name, idx.uuid, e);
+                    tracing::warn!("Failed to get statistics for index {} ({}): {}", idx.name, idx.uuid, e);
                     return None;
                 }
             };
@@ -2422,20 +2438,20 @@ impl BaseTable for NativeTable {
             let stats: serde_json::Value = match serde_json::from_str(&stats) {
                 Ok(stats) => stats,
                 Err(e) => {
-                    log::warn!("Failed to deserialize index statistics for index {} ({}): {}", idx.name, idx.uuid, e);
+                    tracing::warn!("Failed to deserialize index statistics for index {} ({}): {}", idx.name, idx.uuid, e);
                     return None;
                 }
             };
 
             let Some(index_type) = stats.get("index_type").and_then(|v| v.as_str()) else {
-                log::warn!("Index statistics was missing 'index_type' field for index {} ({})", idx.name, idx.uuid);
+                tracing::warn!("Index statistics was missing 'index_type' field for index {} ({})", idx.name, idx.uuid);
                 return None;
             };
 
             let index_type: crate::index::IndexType = match index_type.parse() {
                 Ok(index_type) => index_type,
                 Err(e) => {
-                    log::warn!("Failed to parse index type for index {} ({}): {}", idx.name, idx.uuid, e);
+                    tracing::warn!("Failed to parse index type for index {} ({}): {}", idx.name, idx.uuid, e);
                     return None;
                 }
             };
@@ -2443,7 +2459,7 @@ impl BaseTable for NativeTable {
             let mut columns = Vec::with_capacity(idx.fields.len());
             for field_id in &idx.fields {
                 let Some(field) = dataset.schema().field_by_id(*field_id) else {
-                    log::warn!("The index {} ({}) referenced a field with id {} which does not exist in the schema", idx.name, idx.uuid, field_id);
+                    tracing::warn!("The index {} ({}) referenced a field with id {} which does not exist in the schema", idx.name, idx.uuid, field_id);
                     return None;
                 };
                 columns.push(field.name.clone());
@@ -4207,5 +4223,90 @@ mod tests {
             reads <= 20,
             "Binary search read {reads} manifests for {num_versions} versions, expected <= 20"
         );
+    }
+
+    #[tokio::test]
+    async fn test_query_produces_tracing_span() {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        // Collect (name, span_id, parent_id) tuples via a custom layer
+        #[derive(Debug, Clone)]
+        struct SpanInfo {
+            name: String,
+            id: u64,
+            parent_id: Option<u64>,
+        }
+        let spans: Arc<Mutex<Vec<SpanInfo>>> = Arc::new(Mutex::new(Vec::new()));
+        let spans_clone = spans.clone();
+
+        struct SpanCollector(Arc<Mutex<Vec<SpanInfo>>>);
+        impl<S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>>
+            tracing_subscriber::Layer<S> for SpanCollector
+        {
+            fn on_new_span(
+                &self,
+                attrs: &tracing::span::Attributes<'_>,
+                id: &tracing::span::Id,
+                ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let parent_id = attrs
+                    .parent()
+                    .cloned()
+                    .or_else(|| ctx.current_span().id().cloned())
+                    .map(|pid| pid.into_u64());
+                self.0.lock().unwrap().push(SpanInfo {
+                    name: attrs.metadata().name().to_string(),
+                    id: id.into_u64(),
+                    parent_id,
+                });
+            }
+        }
+
+        let subscriber = tracing_subscriber::registry().with(SpanCollector(spans_clone));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let tmp_dir = tempdir().unwrap();
+        let uri = tmp_dir.path().to_str().unwrap();
+        let db = crate::connect(uri).execute().await.unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let data = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let table = db.create_table("test_spans", data).execute().await.unwrap();
+
+        // This should produce a "lancedb.table.query" span
+        let _results = table.query().execute().await.unwrap();
+
+        let collected = spans.lock().unwrap();
+        assert!(
+            collected.iter().any(|s| s.name == "lancedb.table.query"),
+            "Expected 'lancedb.table.query' span, found: {:?}",
+            collected.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+
+        // Verify that the query execution span is present
+        let execute_span = collected
+            .iter()
+            .find(|s| s.name == "lancedb.query.execute")
+            .expect("lancedb.query.execute span should exist");
+
+        // Verify parent-child: lancedb.native.query should be a child of
+        // lancedb.query.execute (confirming span propagation works)
+        let native_query = collected.iter().find(|s| s.name == "lancedb.native.query");
+        if let Some(nq) = native_query {
+            assert_eq!(
+                nq.parent_id,
+                Some(execute_span.id),
+                "lancedb.native.query should be a child of lancedb.query.execute"
+            );
+        }
+
+        // All spans should have valid IDs (non-zero)
+        for span in collected.iter() {
+            assert!(span.id > 0, "Span '{}' has invalid id 0", span.name);
+        }
     }
 }

--- a/rust/lancedb/src/table/optimize.rs
+++ b/rust/lancedb/src/table/optimize.rs
@@ -12,7 +12,7 @@ use lance::dataset::cleanup::RemovalStats;
 use lance::dataset::optimize::{CompactionMetrics, IndexRemapperOptions, compact_files};
 use lance::index::DatasetIndexExt;
 use lance_index::optimize::OptimizeOptions;
-use log::info;
+use tracing::info;
 
 pub use chrono::Duration;
 pub use lance::dataset::optimize::CompactionOptions;


### PR DESCRIPTION
## Summary

- Add structured tracing and OpenTelemetry OTLP export to Rust core and Node.js bindings, enabling end-to-end distributed tracing from TypeScript through to low-level I/O
- Hot-reloadable subscriber pattern (`init_subscriber` + `upgrade_to_otlp`) allows OTLP to be enabled at runtime without restarting
- W3C traceparent propagation from JS callers into Rust spans via `withTraceparent()` / `getTraceparent()` + `napi_span!` macro

### Rust core (`rust/lancedb`)
- New `profiling` module: `ReloadHandle`, `OtlpGuard` (with `Drop` impl), fmt/json/OTLP subscribers
- `profiling` and `profiling-otlp` feature flags (zero-cost when disabled)
- I/O tracking: OTel histograms/counters per operation, proper `Instant` timing on all async `ObjectStore` methods, `OnceLock` singleton for meter instruments
- `#[instrument]` spans on key Table methods (query, add, update, delete, count_rows, create_index, optimize)
- Type-safe downcast in `hybrid.rs` (`as_any().downcast_ref()` instead of panicking `downcast_array`)

### Node.js bindings (`nodejs`)
- `initProfiling()` NAPI function for runtime OTLP hot-swap
- `withTraceparent()` + `getTraceparent()` with lazy-cached `@opentelemetry/api` detection
- `napi_span!` macro deduplicates traceparent handling across 9 call sites
- `@opentelemetry/api` as optional `peerDependency`

### Code review fixes applied
- **S1**: Proper `Instant::now()` timing on head/delete/copy/rename (was recording 0.0)
- **S2**: fmt layer wrapped with `LevelFilter` in `upgrade_to_otlp()` to prevent TRACE flood
- **W1**: `// SAFETY:` comment on `downcast_raw`
- **W2**: `IoMetrics` as `OnceLock` singleton (was re-creating per `wrap()` call)
- **W3**: Safe downcast in `OriginalScores::save/restore_original_scores`
- **W4**: `put_part` wraps returned future for duration measurement
- **W5**: Module-level lazy cache for `require("@opentelemetry/api")`
- **W6**: `initProfiling` doc corrected from "must call before" to "can call anytime"
- **W7**: `OtlpGuard` implements `Drop` for automatic shutdown
- **B1**: `op` parameter as `&'static str` to avoid allocation
- **B2**: `napi_span!` macro replaces 9 duplicated blocks
- **B3**: `level_from_env()` doc clarifies simple-level-only support
- **B5**: Enhanced `SpanCollector` tests with parent-child relationship assertions
- **B6**: `@opentelemetry/api` as optional peerDependency

## Test plan

- [x] `cargo check --quiet --tests --examples` — compiles cleanly
- [x] `cargo clippy --quiet --tests --examples` — no warnings
- [x] `cargo test --quiet -p lancedb` — 347 passed, 1 ignored
- [x] `npm run build` in nodejs — compiles successfully
- [x] Manual E2E: trinity lance service → query → Tempo trace shows 16 Rust spans with correct parent-child hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)