### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.1.0"
+current_version = "0.1.3"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ components have been removed.
 | | |
 |---|---|
 | Upstream repo | https://github.com/lancedb/lancedb |
-| Based on upstream version | **0.27.2-beta.1** |
+| Based on upstream version | **0.28.0-beta.1** |
 
 See `[workspace.metadata.upstream]` in `Cargo.toml` for the current upstream version tag.
 

--- a/nodejs/Cargo.toml
+++ b/nodejs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lancedb-nodejs"
 edition.workspace = true
-version = "0.1.2"
+version = "0.1.3"
 license.workspace = true
 description.workspace = true
 repository.workspace = true

--- a/nodejs/npm/darwin-arm64/package.json
+++ b/nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@delta-ai/lancedb-darwin-arm64",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"os": [
 		"darwin"
 	],

--- a/nodejs/npm/linux-arm64-gnu/package.json
+++ b/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@delta-ai/lancedb-linux-arm64-gnu",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"os": [
 		"linux"
 	],

--- a/nodejs/npm/linux-arm64-musl/package.json
+++ b/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@delta-ai/lancedb-linux-arm64-musl",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"os": [
 		"linux"
 	],

--- a/nodejs/npm/linux-x64-gnu/package.json
+++ b/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@delta-ai/lancedb-linux-x64-gnu",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"os": [
 		"linux"
 	],

--- a/nodejs/npm/linux-x64-musl/package.json
+++ b/nodejs/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@delta-ai/lancedb-linux-x64-musl",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"os": [
 		"linux"
 	],

--- a/nodejs/npm/win32-arm64-msvc/package.json
+++ b/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@delta-ai/lancedb-win32-arm64-msvc",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"os": [
 		"win32"
 	],

--- a/nodejs/npm/win32-x64-msvc/package.json
+++ b/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@delta-ai/lancedb-win32-x64-msvc",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"os": [
 		"win32"
 	],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -11,7 +11,7 @@
     "ann"
   ],
   "private": false,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lancedb"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 description = "LanceDB: A serverless, low-latency vector database for AI applications"
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump version from 0.1.2 to 0.1.3 across all packages (Rust core, Node.js bindings, platform-specific npm packages, and bumpversion config)

## Changed files
- `.bumpversion.toml` - updated current_version
- `rust/lancedb/Cargo.toml` - Rust core package
- `nodejs/Cargo.toml` - Node.js native bindings
- `nodejs/package.json` - main npm package
- `nodejs/npm/*/package.json` - 7 platform-specific binary packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)