### PR TITLE
feat: propagate traceparent to all NAPI async entry points

### DIFF
--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -16,6 +16,7 @@ import {
 } from "./arrow";
 import { EmbeddingFunctionConfig, getRegistry } from "./embedding/registry";
 import { Connection as LanceDbConnection } from "./native";
+import { getTraceparent } from "./query";
 import { sanitizeTable } from "./sanitize";
 import { LocalTable, Table } from "./table";
 
@@ -338,6 +339,7 @@ export class LocalConnection extends Connection {
       namespacePath ?? [],
       tableNamesOptions?.startAfter,
       tableNamesOptions?.limit,
+      await getTraceparent(),
     );
   }
 
@@ -351,6 +353,7 @@ export class LocalConnection extends Connection {
       namespacePath ?? [],
       cleanseStorageOptions(options?.storageOptions),
       options?.indexCacheSize,
+      await getTraceparent(),
     );
 
     return new LocalTable(innerTable);
@@ -373,6 +376,7 @@ export class LocalConnection extends Connection {
       options?.sourceVersion ?? null,
       options?.sourceTag ?? null,
       options?.isShallow ?? true,
+      await getTraceparent(),
     );
 
     return new LocalTable(innerTable);
@@ -455,6 +459,7 @@ export class LocalConnection extends Connection {
       mode,
       namespacePath ?? [],
       storageOptions,
+      await getTraceparent(),
     );
 
     return new LocalTable(innerTable);
@@ -502,16 +507,17 @@ export class LocalConnection extends Connection {
       mode,
       namespacePath ?? [],
       storageOptions,
+      await getTraceparent(),
     );
     return new LocalTable(innerTable);
   }
 
   async dropTable(name: string, namespacePath?: string[]): Promise<void> {
-    return this.inner.dropTable(name, namespacePath ?? []);
+    return this.inner.dropTable(name, namespacePath ?? [], await getTraceparent());
   }
 
   async dropAllTables(namespacePath?: string[]): Promise<void> {
-    return this.inner.dropAllTables(namespacePath ?? []);
+    return this.inner.dropAllTables(namespacePath ?? [], await getTraceparent());
   }
 }
 

--- a/nodejs/lancedb/merge.ts
+++ b/nodejs/lancedb/merge.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 import { Data, Schema, fromDataToBuffer } from "./arrow";
 import { MergeResult, NativeMergeInsertBuilder } from "./native";
+import { getTraceparent } from "./query";
 
 /** A builder used to create and run a merge insert operation */
 export class MergeInsertBuilder {
@@ -109,7 +110,7 @@ export class MergeInsertBuilder {
     }
 
     const buffer = await fromDataToBuffer(data, undefined, schema);
-    return await this.#native.execute(buffer);
+    return await this.#native.execute(buffer, await getTraceparent());
   }
 }
 

--- a/nodejs/src/connection.rs
+++ b/nodejs/src/connection.rs
@@ -8,6 +8,8 @@ use lancedb::database::{CreateTableMode, Database};
 use napi::bindgen_prelude::*;
 use napi_derive::*;
 
+use tracing::Instrument;
+
 use crate::ConnectionOptions;
 use crate::error::NapiErrorExt;
 use crate::table::Table;
@@ -92,7 +94,9 @@ impl Connection {
         namespace_path: Option<Vec<String>>,
         start_after: Option<String>,
         limit: Option<u32>,
+        traceparent: Option<String>,
     ) -> napi::Result<Vec<String>> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.connection.table_names");
         let mut op = self.get_inner()?.table_names();
         op = op.namespace(namespace_path.unwrap_or_default());
         if let Some(start_after) = start_after {
@@ -101,7 +105,7 @@ impl Connection {
         if let Some(limit) = limit {
             op = op.limit(limit);
         }
-        op.execute().await.default_error()
+        op.execute().instrument(span).await.default_error()
     }
 
     /// Create table from a Apache Arrow IPC (file) buffer.
@@ -118,7 +122,9 @@ impl Connection {
         mode: String,
         namespace_path: Option<Vec<String>>,
         storage_options: Option<HashMap<String, String>>,
+        traceparent: Option<String>,
     ) -> napi::Result<Table> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.connection.create_table");
         let batches = ipc_file_to_batches(buf.to_vec())
             .map_err(|e| napi::Error::from_reason(format!("Failed to read IPC file: {}", e)))?;
         let mode = Self::parse_create_mode_str(&mode)?;
@@ -131,7 +137,7 @@ impl Connection {
                 builder = builder.storage_option(key, value);
             }
         }
-        let tbl = builder.execute().await.default_error()?;
+        let tbl = builder.execute().instrument(span).await.default_error()?;
         Ok(Table::new(tbl))
     }
 
@@ -143,7 +149,9 @@ impl Connection {
         mode: String,
         namespace_path: Option<Vec<String>>,
         storage_options: Option<HashMap<String, String>>,
+        traceparent: Option<String>,
     ) -> napi::Result<Table> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.connection.create_empty_table");
         let schema = ipc_file_to_schema(schema_buf.to_vec()).map_err(|e| {
             napi::Error::from_reason(format!("Failed to marshal schema from JS to Rust: {}", e))
         })?;
@@ -160,7 +168,7 @@ impl Connection {
                 builder = builder.storage_option(key, value);
             }
         }
-        let tbl = builder.execute().await.default_error()?;
+        let tbl = builder.execute().instrument(span).await.default_error()?;
         Ok(Table::new(tbl))
     }
 
@@ -171,7 +179,9 @@ impl Connection {
         namespace_path: Option<Vec<String>>,
         storage_options: Option<HashMap<String, String>>,
         index_cache_size: Option<u32>,
+        traceparent: Option<String>,
     ) -> napi::Result<Table> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.connection.open_table");
         let mut builder = self.get_inner()?.open_table(&name);
 
         builder = builder.namespace(namespace_path.unwrap_or_default());
@@ -184,7 +194,7 @@ impl Connection {
         if let Some(index_cache_size) = index_cache_size {
             builder = builder.index_cache_size(index_cache_size);
         }
-        let tbl = builder.execute().await.default_error()?;
+        let tbl = builder.execute().instrument(span).await.default_error()?;
         Ok(Table::new(tbl))
     }
 
@@ -197,7 +207,9 @@ impl Connection {
         source_version: Option<i64>,
         source_tag: Option<String>,
         is_shallow: bool,
+        traceparent: Option<String>,
     ) -> napi::Result<Table> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.connection.clone_table");
         let mut builder = self
             .get_inner()?
             .clone_table(&target_table_name, &source_uri);
@@ -214,7 +226,7 @@ impl Connection {
 
         builder = builder.is_shallow(is_shallow);
 
-        let tbl = builder.execute().await.default_error()?;
+        let tbl = builder.execute().instrument(span).await.default_error()?;
         Ok(Table::new(tbl))
     }
 
@@ -224,17 +236,29 @@ impl Connection {
         &self,
         name: String,
         namespace_path: Option<Vec<String>>,
+        traceparent: Option<String>,
     ) -> napi::Result<()> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.connection.drop_table");
         let ns = namespace_path.unwrap_or_default();
         self.get_inner()?
             .drop_table(&name, &ns)
+            .instrument(span)
             .await
             .default_error()
     }
 
     #[napi(catch_unwind)]
-    pub async fn drop_all_tables(&self, namespace_path: Option<Vec<String>>) -> napi::Result<()> {
+    pub async fn drop_all_tables(
+        &self,
+        namespace_path: Option<Vec<String>>,
+        traceparent: Option<String>,
+    ) -> napi::Result<()> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.connection.drop_all_tables");
         let ns = namespace_path.unwrap_or_default();
-        self.get_inner()?.drop_all_tables(&ns).await.default_error()
+        self.get_inner()?
+            .drop_all_tables(&ns)
+            .instrument(span)
+            .await
+            .default_error()
     }
 }

--- a/nodejs/src/iterator.rs
+++ b/nodejs/src/iterator.rs
@@ -6,31 +6,39 @@ use lancedb::arrow::SendableRecordBatchStream;
 use lancedb::ipc::batches_to_ipc_file;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use tracing::Instrument;
 
 /** Typescript-style Async Iterator over RecordBatches */
 #[napi]
 pub struct RecordBatchIterator {
     inner: SendableRecordBatchStream,
+    traceparent: Option<String>,
 }
 
 #[napi]
 impl RecordBatchIterator {
-    pub(crate) fn new(inner: SendableRecordBatchStream) -> Self {
-        Self { inner }
+    pub(crate) fn new(inner: SendableRecordBatchStream, traceparent: Option<String>) -> Self {
+        Self { inner, traceparent }
     }
 
     #[napi(catch_unwind)]
     pub async unsafe fn next(&mut self) -> napi::Result<Option<Buffer>> {
-        if let Some(rst) = self.inner.next().await {
-            let batch = rst.map_err(|e| {
-                napi::Error::from_reason(format!("Failed to get next batch from stream: {}", e))
-            })?;
-            batches_to_ipc_file(&[batch])
-                .map_err(|e| napi::Error::from_reason(format!("Failed to write IPC file: {}", e)))
-                .map(|buf| Some(Buffer::from(buf)))
-        } else {
-            // We are done with the stream.
-            Ok(None)
+        let span = crate::tracing_util::napi_span!(self.traceparent, "lancedb.napi.query.next");
+        let result = async {
+            if let Some(rst) = self.inner.next().await {
+                let batch = rst.map_err(|e| {
+                    napi::Error::from_reason(format!("Failed to get next batch from stream: {}", e))
+                })?;
+                batches_to_ipc_file(&[batch])
+                    .map_err(|e| napi::Error::from_reason(format!("Failed to write IPC file: {}", e)))
+                    .map(|buf| Some(Buffer::from(buf)))
+            } else {
+                // We are done with the stream.
+                Ok(None)
+            }
         }
+        .instrument(span)
+        .await;
+        result
     }
 }

--- a/nodejs/src/merge.rs
+++ b/nodejs/src/merge.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use lancedb::{arrow::IntoArrow, ipc::ipc_file_to_batches, table::merge::MergeInsertBuilder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use tracing::Instrument;
 
 use crate::{error::convert_error, table::MergeResult};
 
@@ -51,7 +52,8 @@ impl NativeMergeInsertBuilder {
     }
 
     #[napi(catch_unwind)]
-    pub async fn execute(&self, buf: Buffer) -> napi::Result<MergeResult> {
+    pub async fn execute(&self, buf: Buffer, traceparent: Option<String>) -> napi::Result<MergeResult> {
+        let span = crate::tracing_util::napi_span!(traceparent, "lancedb.napi.merge.execute");
         let data = ipc_file_to_batches(buf.to_vec())
             .and_then(IntoArrow::into_arrow)
             .map_err(|e| {
@@ -60,7 +62,7 @@ impl NativeMergeInsertBuilder {
 
         let this = self.clone();
 
-        let res = this.inner.execute(data).await.map_err(|e| {
+        let res = this.inner.execute(data).instrument(span).await.map_err(|e| {
             napi::Error::from_reason(format!(
                 "Failed to execute merge insert: {}",
                 convert_error(&e)

--- a/nodejs/src/query.rs
+++ b/nodejs/src/query.rs
@@ -162,7 +162,7 @@ impl Query {
                     convert_error(&e)
                 ))
             })?;
-        Ok(RecordBatchIterator::new(inner_stream))
+        Ok(RecordBatchIterator::new(inner_stream, traceparent))
     }
 
     #[napi]
@@ -367,7 +367,7 @@ impl VectorQuery {
                     convert_error(&e)
                 ))
             })?;
-        Ok(RecordBatchIterator::new(inner_stream))
+        Ok(RecordBatchIterator::new(inner_stream, traceparent))
     }
 
     #[napi]
@@ -450,7 +450,7 @@ impl TakeQuery {
                     convert_error(&e)
                 ))
             })?;
-        Ok(RecordBatchIterator::new(inner_stream))
+        Ok(RecordBatchIterator::new(inner_stream, traceparent))
     }
 
     #[napi]


### PR DESCRIPTION
## 📝 Description

Propagate `traceparent` to all remaining async NAPI entry points that perform I/O, so Rust-side tracing spans share the same traceId as the calling TypeScript code. Previously only `query.execute`, `table.add`, `table.update`, `table.delete`, `table.countRows`, `table.createIndex`, and `table.optimize` received a traceparent — all other async functions produced orphaned traces.

### Rust changes
- **connection.rs**: Added `traceparent: Option<String>` + `napi_span!` + `.instrument(span)` to 7 functions: `table_names`, `create_table`, `create_empty_table`, `open_table`, `clone_table`, `drop_table`, `drop_all_tables`
- **iterator.rs**: Store `traceparent` field in `RecordBatchIterator`, use in `next()` with `napi_span!` + `.instrument(span)`
- **query.rs**: Pass `traceparent` to `RecordBatchIterator::new()` in all 3 `execute()` methods (Query, VectorQuery, TakeQuery)
- **merge.rs**: Added `traceparent` to `execute()` + `napi_span!` + `.instrument(span)`

### TypeScript changes
- **connection.ts**: Import `getTraceparent`, pass `await getTraceparent()` to all 7 NAPI calls
- **merge.ts**: Import `getTraceparent`, pass `await getTraceparent()` to `execute()`

### Verification
- `cargo check` passes (both with and without `profiling-otlp` feature)
- `tsc --noEmit` passes
- All 504 existing tests pass (12/12 test suites)

## ✅ Checklist

- [x] My PR title follows the **`type(scope): description`** format (lowercase).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)