### PR TITLE
fix: propagate trace context through RecordBatchIterator.next()

### DIFF
--- a/nodejs/src/iterator.rs
+++ b/nodejs/src/iterator.rs
@@ -6,22 +6,38 @@ use lancedb::arrow::SendableRecordBatchStream;
 use lancedb::ipc::batches_to_ipc_file;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use tracing::Instrument;
 
 /** Typescript-style Async Iterator over RecordBatches */
 #[napi]
 pub struct RecordBatchIterator {
     inner: SendableRecordBatchStream,
+    traceparent: Option<String>,
 }
 
 #[napi]
 impl RecordBatchIterator {
-    pub(crate) fn new(inner: SendableRecordBatchStream) -> Self {
-        Self { inner }
+    pub(crate) fn new(inner: SendableRecordBatchStream, traceparent: Option<String>) -> Self {
+        Self { inner, traceparent }
     }
 
     #[napi(catch_unwind)]
     pub async unsafe fn next(&mut self) -> napi::Result<Option<Buffer>> {
-        if let Some(rst) = self.inner.next().await {
+        // Create a tracing span linked to the remote OTel parent so that
+        // internal lance spans (next_batch_task, get_range, etc.) created
+        // during stream polling are children of the original request trace
+        // instead of becoming orphaned root spans.
+        //
+        // napi_span! attaches the remote context (ContextGuard) only within
+        // its block expression to create the span with the correct parent,
+        // then drops the guard immediately.  The returned tracing::Span is
+        // Send-safe and is held across the await via .instrument().
+        let span = crate::tracing_util::napi_span!(
+            self.traceparent,
+            "lancedb.napi.iterator.next"
+        );
+
+        if let Some(rst) = self.inner.next().instrument(span).await {
             let batch = rst.map_err(|e| {
                 napi::Error::from_reason(format!("Failed to get next batch from stream: {}", e))
             })?;

--- a/nodejs/src/query.rs
+++ b/nodejs/src/query.rs
@@ -162,7 +162,7 @@ impl Query {
                     convert_error(&e)
                 ))
             })?;
-        Ok(RecordBatchIterator::new(inner_stream))
+        Ok(RecordBatchIterator::new(inner_stream, traceparent))
     }
 
     #[napi]
@@ -367,7 +367,7 @@ impl VectorQuery {
                     convert_error(&e)
                 ))
             })?;
-        Ok(RecordBatchIterator::new(inner_stream))
+        Ok(RecordBatchIterator::new(inner_stream, traceparent))
     }
 
     #[napi]
@@ -450,7 +450,7 @@ impl TakeQuery {
                     convert_error(&e)
                 ))
             })?;
-        Ok(RecordBatchIterator::new(inner_stream))
+        Ok(RecordBatchIterator::new(inner_stream, traceparent))
     }
 
     #[napi]


### PR DESCRIPTION
## Summary

- **Root cause**: `RecordBatchIterator::next()` had no trace context — the traceparent was only used during `execute()` (stream creation), so subsequent `next()` calls from the TypeScript `for await` loop produced orphaned root spans (`next_batch_task`, `get_range`, etc.)
- **Fix**: Store the `traceparent` in `RecordBatchIterator` and use `napi_span!` + `.instrument()` on each `next()` call to re-attach the remote OTel context. This pattern creates the tracing span with the correct parent inside a block scope (where `ContextGuard` is valid), drops the guard immediately, then holds the Send-safe span across the `.await` boundary.
- All 3 `RecordBatchIterator::new()` call sites (`Query`, `VectorQuery`, `TakeQuery`) now forward the `traceparent`

## Verification

Before fix: `next_batch_task`, `get_range`, `read_fragment` etc. became orphaned root traces with independent traceIds.

After fix: All 51 spans from a single query are under one trace with a single root span (the POST request). The trace hierarchy:
```
POST /api/lance/.../query                   (server span)
  └─ lancedb.napi.query.execute
       └─ lancedb.query.execute
            └─ lancedb.native.query
                 ├─ create_plan
                 └─ DatasetRecordBatchStream
                      ├─ plan_scan / read_fragment / next_batch_task ...
  └─ lancedb.napi.iterator.next  (×4, one per batch)
```

## Files Changed

- `nodejs/src/iterator.rs` — add `traceparent` field, use `napi_span!` + `.instrument()` in `next()`
- `nodejs/src/query.rs` — pass `traceparent` to `RecordBatchIterator::new()` in 3 call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)